### PR TITLE
Views

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -272,10 +272,10 @@ def discover_schemas(connection):
             key_properties = [c.column_name for c in cols if c.column_key == 'PRI']
             if key_properties:
                 stream['key_properties'] = key_properties
-            
+
             if table_schema in table_info and table_name in table_info[table_schema]:
                 stream['row_count'] = table_info[table_schema][table_name]['row_count']
-                stream['is_view'] = table_info[table_schema][table_name]['is_view']                                                                           
+                stream['is_view'] = table_info[table_schema][table_name]['is_view']
             streams.append(stream)
 
         return {'streams': streams}
@@ -458,4 +458,3 @@ def main():
         do_sync(connection, args.properties, args.state)
     else:
         LOGGER.info("No properties were selected")
-

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -188,6 +188,7 @@ def discover_schemas(connection):
             cursor.execute("""
                 SELECT table_schema,
                        table_name,
+                       table_type,
                        table_rows
                   FROM information_schema.tables
                  WHERE table_schema = %s""",
@@ -196,6 +197,7 @@ def discover_schemas(connection):
             cursor.execute("""
                 SELECT table_schema,
                        table_name,
+                       table_type,
                        table_rows
                   FROM information_schema.tables
                  WHERE table_schema NOT IN (
@@ -203,11 +205,15 @@ def discover_schemas(connection):
                           'performance_schema',
                           'mysql')
             """)
-        row_counts = {}
-        for (db, table, rows) in cursor.fetchall():
-            if db not in row_counts:
-                row_counts[db] = {}
-            row_counts[db][table] = rows
+        table_info = {}
+
+        for (db, table, table_type, rows) in cursor.fetchall():
+            if db not in table_info:
+                table_info[db] = {}
+            table_info[db][table] = {
+                'row_count': rows,
+                'is_view': table_type == 'VIEW'
+            }
 
     with connection.cursor() as cursor:
 
@@ -266,8 +272,9 @@ def discover_schemas(connection):
                     'properties': {c.column_name: schema_for_column(c) for c in cols}
                 },
             }
-            if table_schema in row_counts and table_name in row_counts[table_schema]:
-                stream['row_count'] = row_counts[table_schema][table_name]
+            if table_schema in table_info and table_name in table_info[table_schema]:
+                stream['row_count'] = table_info[table_schema][table_name]['row_count']
+                stream['is_view'] = table_info[table_schema][table_name]['is_view']                                                                           
             streams.append(stream)
 
         return {'streams': streams}

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -412,7 +412,6 @@ def sync_table(connection, db, table, columns, state):
 def generate_messages(con, raw_selections, raw_state):
     indexed_schema = index_schema(discover_schemas(con))
     state = State(raw_state, raw_selections)
-
     for stream in raw_selections['streams']:
         if not stream.get('selected'):
             continue
@@ -460,4 +459,3 @@ def main():
     else:
         LOGGER.info("No properties were selected")
 
-# TODO: How to deal with primary keys for views

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 
 import datetime
@@ -262,16 +261,18 @@ def discover_schemas(connection):
         for (k, cols) in itertools.groupby(columns, lambda c: (c.table_schema, c.table_name)):
             cols = list(cols)
             (table_schema, table_name) = k
-
             stream = {
                 'database': table_schema,
                 'table': table_name,
-                'key_properties': [c.column_name for c in cols if c.column_key == 'PRI'],
                 'schema': {
                     'type': 'object',
                     'properties': {c.column_name: schema_for_column(c) for c in cols}
                 },
             }
+            key_properties = [c.column_name for c in cols if c.column_key == 'PRI']
+            if key_properties:
+                stream['key_properties'] = key_properties
+            
             if table_schema in table_info and table_name in table_info[table_schema]:
                 stream['row_count'] = table_info[table_schema][table_name]['row_count']
                 stream['is_view'] = table_info[table_schema][table_name]['is_view']                                                                           

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -239,7 +239,7 @@ class TestViews(unittest.TestCase):
             cursor.execute(
                 '''
                 CREATE TABLE a_table (
-                  id int,
+                  id int primary key,
                   a int,
                   b int)
                 ''')
@@ -253,7 +253,7 @@ class TestViews(unittest.TestCase):
         if self.con:
             self.con.close()
 
-    def runTest(self):
+    def test_discovery_sets_is_view(self):
         discovered = tap_mysql.discover_schemas(self.con)
 
         is_view = {
@@ -264,3 +264,16 @@ class TestViews(unittest.TestCase):
             is_view,
             {'a_table': False,
              'a_view': True})
+
+    def test_can_set_key_properties(self):
+        discovered = tap_mysql.discover_schemas(self.con)
+
+        discovered_key_properties = {
+            s.get('table'): s.get('key_properties')
+            for s in discovered['streams']
+        }
+
+        self.assertEqual(
+            discovered_key_properties,
+            {'a_table': ['id'],
+             'a_view': None})

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -265,15 +265,28 @@ class TestViews(unittest.TestCase):
             {'a_table': False,
              'a_view': True})
 
-    def test_can_set_key_properties(self):
+    def test_do_not_discover_key_properties_for_view(self):
         discovered = tap_mysql.discover_schemas(self.con)
-
         discovered_key_properties = {
             s.get('table'): s.get('key_properties')
             for s in discovered['streams']
         }
-
         self.assertEqual(
             discovered_key_properties,
             {'a_table': ['id'],
              'a_view': None})
+
+    def test_can_set_key_properties_for_view(self):
+        discovered = tap_mysql.discover_schemas(self.con)
+        for stream in discovered['streams']:
+            if stream['table'] == 'a_view':
+                stream['key_properties'] = ['id']
+                stream['selected'] = True
+                stream['schema']['properties']['a']['selected'] = True
+                
+        messages = list(tap_mysql.generate_messages(self.con, discovered, {}))
+        message = messages[0]
+
+        
+        self.assertTrue(isinstance(message, singer.SchemaMessage))
+        self.assertEqual(message.key_properties, ['id'])

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -246,7 +246,7 @@ class TestViews(unittest.TestCase):
 
             cursor.execute(
                 '''
-                CREATE TABLE a_view AS SELECT id, a FROM a_table
+                CREATE VIEW a_view AS SELECT id, a FROM a_table
                 ''')
 
     def tearDown(self):
@@ -256,7 +256,11 @@ class TestViews(unittest.TestCase):
     def runTest(self):
         discovered = tap_mysql.discover_schemas(self.con)
 
-        stream_names = set([s.get('table') for s in discovered['streams']])
+        is_view = {
+            s.get('table'): s.get('is_view')
+            for s in discovered['streams']
+        }
         self.assertEqual(
-            set(['a_table', 'a_view']),
-            stream_names)             
+            is_view,
+            {'a_table': False,
+             'a_view': True})


### PR DESCRIPTION
Add support for a user specifying primary key fields for views.

This has two parts:

1. Change discover mode to include an `is_view` flag on each stream that indicates whether the stream is a view. Added a test.
2. Add test to confirm that we use the `key_properties` flag from the stream in the `--properties` argument to determine which fields to treat as keys. 