### PR TITLE
Save stream in state

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -21,7 +21,6 @@ import singer.stats
 from singer import utils
 
 
-
 Column = collections.namedtuple('Column', [
     "table_schema",
     "table_name",
@@ -63,9 +62,9 @@ STRING_TYPES = set([
 ])
 
 BYTES_FOR_INTEGER_TYPE = {
-    'tinyint' : 1,
+    'tinyint': 1,
     'smallint': 2,
-    'mediumint' : 3,
+    'mediumint': 3,
     'int': 4,
     'bigint': 8
 }
@@ -74,8 +73,10 @@ FLOAT_TYPES = set(['float', 'double'])
 
 DATETIME_TYPES = set(['datetime', 'timestamp'])
 
+
 class InputException(Exception):
     pass
+
 
 @attr.s
 class StreamState(object):
@@ -114,7 +115,7 @@ class State(object):
                 for s in state.get('streams', []):
                     if s['stream'] == selected_stream_name:
                         stored_stream_state = s
-                if stored_stream_state and stored_stream_state['replication_key'] == selected_rep_key: # pylint: disable=line-too-long
+                if stored_stream_state and stored_stream_state['replication_key'] == selected_rep_key:  # pylint: disable=line-too-long
                     value = stored_stream_state['replication_key_value']
                 stream_state = StreamState(
                     stream=selected_stream_name,
@@ -122,18 +123,18 @@ class State(object):
                     replication_key_value=value)
                 self.streams.append(stream_state)
 
-
     def get_stream_state(self, stream):
         for stream_state in self.streams:
             if stream_state.stream == stream:
                 return stream_state
-            
+
     def make_state_message(self):
         result = {}
         if self.current_stream:
             result['current_stream'] = self.current_stream
         result['streams'] = [s.__dict__ for s in self.streams]
         return singer.StateMessage(value=result)
+
 
 def schema_for_column(c):
 
@@ -251,7 +252,6 @@ def discover_schemas(connection):
                           'mysql')
             """)
 
-
         columns = []
         rec = cursor.fetchone()
         while rec is not None:
@@ -349,7 +349,7 @@ def remove_unwanted_columns(selected, indexed_schema, database, table):
 
     selected_but_unsupported = selected.intersection(unsupported)
     if selected_but_unsupported:
-        LOGGER.warning('For database %s, table %s, columns %s were selected but are not supported. Skipping them.', # pylint: disable=line-too-long
+        LOGGER.warning('For database %s, table %s, columns %s were selected but are not supported. Skipping them.',  # pylint: disable=line-too-long
                        database, table, selected_but_unsupported)
 
     selected_but_nonexistent = selected.difference(all_columns)
@@ -359,7 +359,7 @@ def remove_unwanted_columns(selected, indexed_schema, database, table):
 
     not_selected_but_automatic = automatic.difference(selected)
     if not_selected_but_automatic:
-        LOGGER.warning('For database %s, table %s, columns %s are primary keys but were not selected. Automatically adding them.', # pylint: disable=line-too-long
+        LOGGER.warning('For database %s, table %s, columns %s are primary keys but were not selected. Automatically adding them.',  # pylint: disable=line-too-long
                        database, table, not_selected_but_automatic)
 
     keep = selected.intersection(available).union(automatic)
@@ -416,7 +416,7 @@ def generate_messages(con, raw_selections, raw_state):
     streams = raw_selections['streams']
     if state.current_stream:
         streams = dropwhile(lambda s: s['stream'] != state.current_stream, streams)
-    
+
     for stream in streams:
         if not stream.get('selected'):
             continue
@@ -448,6 +448,7 @@ def generate_messages(con, raw_selections, raw_state):
             yield message
     state.current_stream = None
     yield state.make_state_message()
+
 
 def do_sync(con, raw_selections, raw_state):
     with con.cursor() as cur:

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -413,13 +413,11 @@ def generate_messages(con, raw_selections, raw_state):
     indexed_schema = index_schema(discover_schemas(con))
     state = State(raw_state, raw_selections)
 
-    streams = raw_selections['streams']
+    streams = filter(lambda stream: stream.get('selected'), raw_selections['streams'])
     if state.current_stream:
         streams = dropwhile(lambda s: s['stream'] != state.current_stream, streams)
 
     for stream in streams:
-        if not stream.get('selected'):
-            continue
         state.current_stream = stream['stream']
         yield state.make_state_message()
 

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -222,7 +222,7 @@ class TestSchemaMessages(unittest.TestCase):
 
             selections = tap_mysql.discover_schemas(con)
             selections['streams'][0]['stream'] = 'tab'
-            selections['streams'][0]['selected'] = True            
+            selections['streams'][0]['selected'] = True
             selections['streams'][0]['schema']['properties']['a']['selected'] = True
             messages = list(tap_mysql.generate_messages(con, selections, {}))
             schema_message = list(filter(lambda m: isinstance(m, singer.SchemaMessage), messages))[0]
@@ -247,7 +247,7 @@ class TestCurrentStream(unittest.TestCase):
             cursor.execute('CREATE TABLE b (val int)')
             cursor.execute('INSERT INTO a (val) VALUES (1)')
             cursor.execute('INSERT INTO b (val) VALUES (1)')
-            
+
         discovered = tap_mysql.discover_schemas(self.con)
         for stream in discovered['streams']:
             stream['selected'] = True
@@ -316,15 +316,14 @@ class TestViews(unittest.TestCase):
         discovered = tap_mysql.discover_schemas(self.con)
         for stream in discovered['streams']:
             stream['stream'] = stream['table']
-            
+
             if stream['table'] == 'a_view':
                 stream['key_properties'] = ['id']
                 stream['selected'] = True
                 stream['schema']['properties']['a']['selected'] = True
-                
+
         messages = list(tap_mysql.generate_messages(self.con, discovered, {}))
         schema_message = list(filter(lambda m: isinstance(m, singer.SchemaMessage), messages))[0]
-        
+
         self.assertTrue(isinstance(schema_message, singer.SchemaMessage))
         self.assertEqual(schema_message.key_properties, ['id'])
-


### PR DESCRIPTION
Before processing a table, set `current_stream` in the state to the name of the corresponding stream. If `current_stream` is set in the starting state, skip over streams until we get to the current stream. Added some tests to confirm both of those behaviors.