### PR TITLE
Make `type` part of the standard keys we include in a schema

### DIFF
--- a/tap_mysql/schema.py
+++ b/tap_mysql/schema.py
@@ -13,7 +13,8 @@ STANDARD_KEYS = [
     'exclusiveMaximum',
     'multipleOf',
     'maxLength',
-    'format'
+    'format',
+    'type'
 ]
 
 @attr.s # pylint: disable=too-many-instance-attributes


### PR DESCRIPTION
Before:

```
{
  "schema": {
    "properties": {
      "updated_at": {
        "inclusion": "available",
        "sqlDatatype": "datetime",
        "format": "date-time"
      }
    }
  }
}
```

After:

```
{
  "schema": {
    "type": "object",
    "properties": {
      "updated_at": {
        "inclusion": "available",
        "type": "string",
        "sqlDatatype": "datetime",
        "format": "date-time"
      }
    }
  }
}
```