### PR TITLE
Use new metrics format in singer-python 1.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='tap-mysql',
       install_requires=[
           'attrs==16.3.0',
           'pendulum==1.2.0',
-          'singer-python==1.6.0a2',
+          'singer-python==1.6.0',
           'PyMySQL==0.7.11',
       ],
       entry_points='''


### PR DESCRIPTION
Sample output:

```
INFO METRIC: {"type": "counter", "value": 4, "tags": {"database": "tap_mysql", "table": "users"}, "metric": "record_count"}
INFO METRIC: {"type": "timer", "value": 0.001995563507080078, "tags": {"job_type": "sync_table", "database": "tap_mysql", "status": "succeeded", "table": "users"}, "metric": "job_duration"}
```