### PR TITLE
make database name an optional config property; other cleanup

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -37,20 +37,20 @@ REQUIRED_CONFIG_KEYS = [
     'host',
     'port',
     'user',
-    'password',
-    'database'
+    'password'
 ]
 
 LOGGER = singer.get_logger()
 
 
 def open_connection(config):
-    return pymysql.connect(
-        host=config['host'],
-        user=config['user'],
-        password=config['password'],
-        database=config['database'],
-    )
+    connection_args = {'host': config['host'],
+                       'user': config['user'],
+                       'password': config['password']}
+    database = config.get('database')
+    if database:
+        connection_args['database'] = database
+    return pymysql.connect(**connection_args)
 
 STRING_TYPES = set([
     'char',
@@ -231,6 +231,7 @@ def schema_for_column(c):
     else:
         result = Schema(None,
                         inclusion='unsupported',
+                        sqlDatatype=c.column_type,
                         description='Unsupported column type {}'.format(c.column_type))
     return result
 

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -198,7 +198,7 @@ def schema_for_column(c):
     result.sqlDatatype = c.column_type
 
     if t in BYTES_FOR_INTEGER_TYPE:
-        result.type = 'integer'
+        result.type = ['null', 'integer']
         bits = BYTES_FOR_INTEGER_TYPE[t] * 8
         if 'unsigned' in c.column_type:
             result.minimum = 0
@@ -208,10 +208,10 @@ def schema_for_column(c):
             result.maximum = 2 ** (bits - 1) - 1
 
     elif t in FLOAT_TYPES:
-        result.type = 'number'
+        result.type = ['null', 'number']
 
     elif t == 'decimal':
-        result.type = 'number'
+        result.type = ['null', 'number']
         result.exclusiveMaximum = 10 ** (c.numeric_precision - c.numeric_scale)
         result.multipleOf = 10 ** (0 - c.numeric_scale)
         if 'unsigned' in c.column_type:
@@ -221,11 +221,11 @@ def schema_for_column(c):
         return result
 
     elif t in STRING_TYPES:
-        result.type = 'string'
+        result.type = ['null', 'string']
         result.maxLength = c.character_maximum_length
 
     elif t in DATETIME_TYPES:
-        result.type = 'string'
+        result.type = ['null', 'string']
         result.format = 'date-time'
 
     else:

--- a/tap_mysql/schema.py
+++ b/tap_mysql/schema.py
@@ -50,8 +50,6 @@ class Schema(object):
             result['properties'] = {
                 k: v.to_json() for k, v in self.properties.items() # pylint: disable=no-member
             }
-        if not self.type:
-            raise ValueError("Type is required")
 
         for key in STANDARD_KEYS:
             if self.__dict__[key] is not None:

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -62,7 +62,7 @@ class TestTypeMapping(unittest.TestCase):
 
     def test_decimal(self):
         self.assertEqual(self.schema.properties['c_decimal'],
-                         tap_mysql.Schema('number',
+                         tap_mysql.Schema(['null', 'number'],
                                           sqlDatatype='decimal(10,0)',
                                           inclusion='available',
                                           exclusiveMaximum=10000000000,
@@ -71,7 +71,7 @@ class TestTypeMapping(unittest.TestCase):
 
     def test_decimal_unsigned(self):
         self.assertEqual(self.schema.properties['c_decimal_2_unsigned'],
-                         tap_mysql.Schema('number',
+                         tap_mysql.Schema(['null', 'number'],
                                           sqlDatatype='decimal(5,2) unsigned',
                                           inclusion='available',
                                           exclusiveMaximum=1000,
@@ -80,7 +80,7 @@ class TestTypeMapping(unittest.TestCase):
 
     def test_decimal_with_defined_scale_and_precision(self):
         self.assertEqual(self.schema.properties['c_decimal_2'],
-                         tap_mysql.Schema('number',
+                         tap_mysql.Schema(['null', 'number'],
                                           sqlDatatype='decimal(11,2)',
                                           inclusion='available',
                                           exclusiveMaximum=1000000000,
@@ -89,14 +89,14 @@ class TestTypeMapping(unittest.TestCase):
 
     def test_tinyint(self):
         self.assertEqual(self.schema.properties['c_tinyint'],
-                         tap_mysql.Schema('integer',
+                         tap_mysql.Schema(['null', 'integer'],
                                           sqlDatatype='tinyint(4)',
                                           inclusion='available', minimum=-128,
                                           maximum=127))
 
     def test_smallint(self):
         self.assertEqual(self.schema.properties['c_smallint'],
-                         tap_mysql.Schema('integer',
+                         tap_mysql.Schema(['null', 'integer'],
                                           sqlDatatype='smallint(6)',
                                           inclusion='available',
                                           minimum=-32768,
@@ -104,7 +104,7 @@ class TestTypeMapping(unittest.TestCase):
 
     def test_mediumint(self):
         self.assertEqual(self.schema.properties['c_mediumint'],
-                         tap_mysql.Schema('integer',
+                         tap_mysql.Schema(['null', 'integer'],
                                           sqlDatatype='mediumint(9)',
                                           inclusion='available',
                                           minimum=-8388608,
@@ -113,7 +113,7 @@ class TestTypeMapping(unittest.TestCase):
 
     def test_int(self):
         self.assertEqual(self.schema.properties['c_int'],
-                         tap_mysql.Schema('integer',
+                         tap_mysql.Schema(['null', 'integer'],
                                           sqlDatatype='int(11)',
                                           inclusion='available',
                                           minimum=-2147483648,
@@ -121,7 +121,7 @@ class TestTypeMapping(unittest.TestCase):
 
     def test_bigint(self):
         self.assertEqual(self.schema.properties['c_bigint'],
-                         tap_mysql.Schema('integer',
+                         tap_mysql.Schema(['null', 'integer'],
                                           sqlDatatype='bigint(20)',
                                           inclusion='available',
                                           minimum=-9223372036854775808,
@@ -129,14 +129,14 @@ class TestTypeMapping(unittest.TestCase):
 
     def test_float(self):
         self.assertEqual(self.schema.properties['c_float'],
-                         tap_mysql.Schema('number',
+                         tap_mysql.Schema(['null', 'number'],
                                           inclusion='available',
                                           sqlDatatype='float'))
 
 
     def test_double(self):
         self.assertEqual(self.schema.properties['c_double'],
-                         tap_mysql.Schema('number',
+                         tap_mysql.Schema(['null', 'number'],
                                           inclusion='available',
                                           sqlDatatype='double'))
 
@@ -176,13 +176,13 @@ class TestIndexDiscoveredSchema(unittest.TestCase):
                 "tap_mysql_test": {
                     "tab": {
                         "b": tap_mysql.Schema(
-                            'integer',
+                            ['null', 'integer'],
                             sqlDatatype='int(11)',
                             inclusion="available",
                             maximum=2147483647,
                             minimum=-2147483648),
                         "a": tap_mysql.Schema(
-                            'integer',
+                            ['null', 'integer'],
                             sqlDatatype='int(11)',
                             inclusion="available",
                             maximum=2147483647,


### PR DESCRIPTION
- make `database` property optional in the config and connection w/o it if it isn't provided
- include `sqlDatatype` as part of discovered columns even if those types aren't supported
- remove `type` requirement for the schema. for unsupported properties we don't know the appropriate JSON schema type, and `type` is [not required](https://github.com/json-schema/json-schema/issues/172)
- make schema for columns with `type` definition validate null values as well