### PR TITLE
Full table replication

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='tap-mysql',
       install_requires=[
           'attrs==16.3.0',
           'pendulum==1.2.0',
-          'singer-python==1.7.0',
+          'singer-python==1.8.0',
           'PyMySQL==0.7.11',
       ],
       entry_points='''

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -497,10 +497,10 @@ def generate_messages(con, catalog, raw_state):
     LOGGER.info('%d streams total, %d are selected', len(catalog.streams), len(streams))
     LOGGER.info('State is %s', state.make_state_message())
     if state.current_stream:
-        streams = dropwhile(lambda s: s.stream != state.current_stream, streams)
+        streams = dropwhile(lambda s: s.tap_stream_id != state.current_stream, streams)
 
     for catalog_entry in streams:
-        state.current_stream = catalog_entry.stream
+        state.current_stream = catalog_entry.tap_stream_id
         yield state.make_state_message()
 
         database = catalog_entry.database

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -82,6 +82,22 @@ class InputException(Exception):
 
 @attr.s
 class StreamState(object):
+    '''Represents the state for a single stream.
+
+    The state for a stream consists of four properties:
+
+      * tap_stream_id - the identifier for the stream
+      * replication_key (optional, string) - name of the field used for
+        bookmarking
+      * replication_key_value (optional, string or int) - current value of
+        the bookmark
+      * version (optional, int) - the version number of the stream.
+    
+    Use StreamState.from_dict(raw, catalog_entry) to build a StreamState
+    based on the raw dict and the singer.catalog.CatalogEntry for the
+    stream.
+
+    '''
     tap_stream_id = attr.ib()
     replication_key = attr.ib(default=None)
     replication_key_value = attr.ib(default=None)
@@ -94,8 +110,9 @@ class StreamState(object):
     @classmethod
     def from_dict(cls, raw, catalog_entry):
         '''Builds a StreamState from a raw dictionary containing the entry for
-        this stream in the state file, as well as a CatalogEntry.'''
+        this stream in the state file, as well as a CatalogEntry.
 
+        '''
         result = StreamState(catalog_entry.tap_stream_id)
         if catalog_entry.replication_key:
             result.replication_key = catalog_entry.replication_key
@@ -116,9 +133,22 @@ def replication_key_by_table(raw_selections):
     return result
 
 
+# TODO: Use tap_stream_id for current stream
 @attr.s
 class State(object):
+    '''Represents the full state.
 
+    Two properties:
+
+      * current_stream - When the tap is in the middle of syncing a
+        stream, this will be set to the tap_stream_id for that stream.
+      * streams - List of StreamState objects, one for each selected
+        stream.
+
+    Use State.from_dict(raw, catalog) to build a StreamState based
+    on the raw dict and the singer.catalog.Catalog.
+
+    '''
     current_stream = attr.ib()
     streams = attr.ib()
 
@@ -308,6 +338,7 @@ def do_discover(connection):
     discover_catalog(connection).dump()
 
 def primary_key_columns(connection, db, table):
+
     '''Return a list of names of columns that are primary keys in the given
     table in the given db.'''
     with connection.cursor() as cur:

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -86,8 +86,8 @@ class StreamState(object):
     replication_key = attr.ib(default=None)
     replication_key_value = attr.ib(default=None)
     version = attr.ib(default=None)
-    
-    
+
+
     def update(self, record):
         self.replication_key_value = record[self.replication_key]
 

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -92,7 +92,7 @@ class StreamState(object):
       * replication_key_value (optional, string or int) - current value of
         the bookmark
       * version (optional, int) - the version number of the stream.
-    
+
     Use StreamState.from_dict(raw, catalog_entry) to build a StreamState
     based on the raw dict and the singer.catalog.CatalogEntry for the
     stream.

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -107,10 +107,11 @@ def replication_key_by_table(raw_selections):
     return result
 
 
+@attr.s
 class State(object):
-    def __init__(self, current_stream, streams):
-        self.current_stream = current_stream
-        self.streams = streams
+
+    current_stream = attr.ib()
+    streams = attr.ib()
 
     @classmethod
     def from_dict(cls, raw, catalog):

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -85,8 +85,9 @@ class StreamState(object):
     tap_stream_id = attr.ib()
     replication_key = attr.ib(default=None)
     replication_key_value = attr.ib(default=None)
-    table_version = attr.ib(default=None)
-
+    version = attr.ib(default=None)
+    
+    
     def update(self, record):
         self.replication_key_value = record[self.replication_key]
 

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -480,7 +480,10 @@ def sync_table(connection, db, table, columns, catalog_entry, state):
                 rec = dict(zip(columns, row_to_persist))
                 if stream_state.replication_key is not None:
                     stream_state.update(rec)
-                yield singer.RecordMessage(stream=catalog_entry.stream, record=rec, version=stream_state.version)
+                yield singer.RecordMessage(
+                    stream=catalog_entry.stream,
+                    record=rec,
+                    version=stream_state.version)
                 if rows_saved % 1000 == 0:
                     yield state.make_state_message()
                 row = cursor.fetchone()

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -313,7 +313,7 @@ class TestStreamVersionFullTable(unittest.TestCase):
             stream.key_properties = []
             stream.schema.properties['val'].selected = True
             stream.stream = stream.table
-        
+
     def tearDown(self):
         if self.con:
             self.con.close()
@@ -335,10 +335,10 @@ class TestStreamVersionFullTable(unittest.TestCase):
         }
         (message_types, versions) = message_types_and_versions(
             tap_mysql.generate_messages(self.con, self.catalog, state))
-        
+
         self.assertEqual(['RecordMessage', 'ActivateVersionMessage'], message_types)
         self.assertEqual(versions, [1, 1])
-        
+
 
 class TestStreamVersionIncremental(unittest.TestCase):
 
@@ -356,16 +356,16 @@ class TestStreamVersionIncremental(unittest.TestCase):
             stream.schema.properties['val'].selected = True
             stream.stream = stream.table
             stream.replication_key = 'updated'
-        
+
     def tearDown(self):
         if self.con:
             self.con.close()
 
-            
+
     def test_with_no_state(self):
         state = {}
         (message_types, versions) = message_types_and_versions(
-            tap_mysql.generate_messages(self.con, self.catalog, state))        
+            tap_mysql.generate_messages(self.con, self.catalog, state))
         self.assertEqual(
             ['ActivateVersionMessage', 'RecordMessage', 'RecordMessage'],
             message_types)
@@ -380,13 +380,13 @@ class TestStreamVersionIncremental(unittest.TestCase):
                 'version': 1}]
         }
         (message_types, versions) = message_types_and_versions(
-            tap_mysql.generate_messages(self.con, self.catalog, state))        
+            tap_mysql.generate_messages(self.con, self.catalog, state))
         self.assertEqual(
             ['ActivateVersionMessage', 'RecordMessage', 'RecordMessage'],
             message_types)
         self.assertTrue(isinstance(versions[0], int))
-        self.assertEqual(versions[0], versions[1])        
-        
+        self.assertEqual(versions[0], versions[1])
+
 class TestViews(unittest.TestCase):
     def setUp(self):
         self.con = get_test_connection()

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -273,6 +273,7 @@ class TestCurrentStream(unittest.TestCase):
             stream.key_properties = []
             stream.schema.properties['val'].selected = True
             stream.stream = stream.table
+            stream.tap_stream_id = stream.table
 
     def tearDown(self):
         if self.con:

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -65,6 +65,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_decimal(self):
         self.assertEqual(self.schema.properties['c_decimal'],
                          Schema(['null', 'number'],
+                                selected=False,
                                 sqlDatatype='decimal(10,0)',
                                 inclusion='available',
                                 maximum=10000000000,
@@ -76,6 +77,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_decimal_unsigned(self):
         self.assertEqual(self.schema.properties['c_decimal_2_unsigned'],
                          Schema(['null', 'number'],
+                                selected=False,
                                 sqlDatatype='decimal(5,2) unsigned',
                                 inclusion='available',
                                 maximum=1000,
@@ -86,6 +88,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_decimal_with_defined_scale_and_precision(self):
         self.assertEqual(self.schema.properties['c_decimal_2'],
                          Schema(['null', 'number'],
+                                selected=False,
                                 sqlDatatype='decimal(11,2)',
                                 inclusion='available',
                                 maximum=1000000000,
@@ -97,6 +100,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_tinyint(self):
         self.assertEqual(self.schema.properties['c_tinyint'],
                          Schema(['null', 'integer'],
+                                selected=False,
                                 sqlDatatype='tinyint(4)',
                                 inclusion='available', minimum=-128,
                                 maximum=127))
@@ -104,6 +108,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_smallint(self):
         self.assertEqual(self.schema.properties['c_smallint'],
                          Schema(['null', 'integer'],
+                                selected=False,
                                 sqlDatatype='smallint(6)',
                                 inclusion='available',
                                 minimum=-32768,
@@ -112,6 +117,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_mediumint(self):
         self.assertEqual(self.schema.properties['c_mediumint'],
                          Schema(['null', 'integer'],
+                                selected=False,
                                 sqlDatatype='mediumint(9)',
                                 inclusion='available',
                                 minimum=-8388608,
@@ -121,6 +127,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_int(self):
         self.assertEqual(self.schema.properties['c_int'],
                          Schema(['null', 'integer'],
+                                selected=False,
                                 sqlDatatype='int(11)',
                                 inclusion='available',
                                 minimum=-2147483648,
@@ -129,6 +136,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_bigint(self):
         self.assertEqual(self.schema.properties['c_bigint'],
                          Schema(['null', 'integer'],
+                                selected=False,
                                 sqlDatatype='bigint(20)',
                                 inclusion='available',
                                 minimum=-9223372036854775808,
@@ -137,6 +145,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_float(self):
         self.assertEqual(self.schema.properties['c_float'],
                          Schema(['null', 'number'],
+                                selected=False,
                                 inclusion='available',
                                 sqlDatatype='float'))
 
@@ -144,6 +153,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_double(self):
         self.assertEqual(self.schema.properties['c_double'],
                          Schema(['null', 'number'],
+                                selected=False,
                                 inclusion='available',
                                 sqlDatatype='double'))
 
@@ -184,12 +194,14 @@ class TestIndexDiscoveredSchema(unittest.TestCase):
                     "tab": {
                         "b": Schema(
                             ['null', 'integer'],
+                            selected=False,
                             sqlDatatype='int(11)',
                             inclusion="available",
                             maximum=2147483647,
                             minimum=-2147483648),
                         "a": Schema(
                             ['null', 'integer'],
+                            selected=False,
                             sqlDatatype='int(11)',
                             inclusion="available",
                             maximum=2147483647,


### PR DESCRIPTION
The main motivation is to allow full table replication by adding version numbers to records and issuing ACTIVATE_VERSION messages, but I made several other changes here also.

1. Refactor State and StreamState so that their constructors don't do anything other than set properties. Now use `State.from_dict()` to build the state from the raw dictionary. I did this because when I went to add a property to StreamState, I found the constructor to be confusing since it was doing so much stuff.
2. Use tap_stream_id to identify the stream in the state.
3. Use tap_stream_id to indicate the current stream in the state.
4. Add a "version" property to StreamState.
5. Add the version number to each record.
6. Emit an ActivateVersion message for each table. For incremental tables, it comes at the beginning of the sync. For full-table replication, it comes at the end.
7. Added unit tests for each of four cases:
    1. Incremental syncing with no initial state
    1. Incremental syncing with an initial state
    1. Full-table syncing with no initial state
    1. Full-table syncing with an initial state
8. In discovery mode:
    1. Mark all nodes with `"selected": false`
    2. Set "schema" to be equal to the table name