### PR TITLE
Refactor and generalize some functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='tap-mysql',
       install_requires=[
           'attrs==16.3.0',
           'pendulum==1.2.0',
-          'singer-python==1.9.0',
+          'singer-python==1.9.1',
           'PyMySQL==0.7.11',
       ],
       entry_points='''

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -356,8 +356,7 @@ def primary_key_columns(connection, db, table):
         return set([c[0] for c in cur.fetchall()])
 
 
-# TODO: Generalize this. Use tap_stream_id rather than database and table.
-# Maybe make it a method on Catalog or CatalogEntry.
+# TODO: Move this into a common library.
 def desired_columns(selected, table_schema):
 
     '''Return the set of column names we need to include in the SELECT.
@@ -484,34 +483,36 @@ def sync_table(connection, catalog_entry, state):
             yield activate_version_message
 
 
-def generate_messages(con, catalog, raw_state):
-    discovered_catalog = discover_catalog(con)
-    state = State.from_dict(raw_state, catalog)
+def resolve_catalog(con, catalog, state):
 
+    discovered = discover_catalog(con)
+
+    # Filter catalog to include only selected streams
     streams = list(filter(lambda stream: stream.is_selected(), catalog.streams))
-    LOGGER.info('%d streams total, %d are selected', len(catalog.streams), len(streams))
-    LOGGER.info('State is %s', state.make_state_message())
-    if state.current_stream:
-        streams = dropwhile(lambda s: s.tap_stream_id != state.current_stream, streams)
 
+    # If the state says we were in the middle of processing a stream, skip
+    # to that stream.
+    if state.current_stream:
+        streams = dropwhile(lambda s: s.tap_stream_id != state.current_stream, streams)    
+
+    result = Catalog(streams=[])
+        
     # Iterate over the streams in the input catalog and match each one up
     # with the same stream in the discovered catalog.
     for catalog_entry in streams:
-        state.current_stream = catalog_entry.tap_stream_id
-        yield state.make_state_message()
 
-        discovered_table = discovered_catalog.get_stream(catalog_entry.tap_stream_id)
+        discovered_table = discovered.get_stream(catalog_entry.tap_stream_id)
         if not discovered_table:
             LOGGER.warning('Database %s table %s was selected but does not exist',
                            catalog_entry.database, catalog_entry.table)
-
+            next
         selected = set([k for k, v in catalog_entry.schema.properties.items()
                         if v.selected or k == catalog_entry.replication_key])
 
         # These are the columns we need to select
         columns = desired_columns(selected, discovered_table.schema)
 
-        catalog_entry = CatalogEntry(
+        result.streams.append(CatalogEntry(
             tap_stream_id=catalog_entry.tap_stream_id,
             key_properties=catalog_entry.key_properties,
             stream=catalog_entry.stream,
@@ -523,8 +524,20 @@ def generate_messages(con, catalog, raw_state):
                 properties={col: discovered_table.schema.properties[col]
                             for col in columns}
             )
-        )
+        ))
 
+    return result
+
+        
+def generate_messages(con, catalog, raw_state):
+    state = State.from_dict(raw_state, catalog)
+    catalog = resolve_catalog(con, catalog, state)
+    
+    # Iterate over the streams in the input catalog and match each one up
+    # with the same stream in the discovered catalog.
+    for catalog_entry in catalog.streams:
+        state.current_stream = catalog_entry.tap_stream_id
+        yield state.make_state_message()
         yield singer.SchemaMessage(
             stream=catalog_entry.stream,
             schema=catalog_entry.schema.to_dict(),

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -80,7 +80,7 @@ class InputException(Exception):
     pass
 
 
-# TODO: Maybe put in common library. Not singer-python. singer-db-utils?
+# TODO: Maybe put in a singer-db-utils library.
 @attr.s
 class StreamState(object):
     '''Represents the state for a single stream.
@@ -134,7 +134,7 @@ def replication_key_by_table(raw_selections):
     return result
 
 
-# TODO: Maybe put in common library
+# TODO: Maybe put in a singer-db-utils library.
 @attr.s
 class State(object):
     '''Represents the full state.
@@ -356,7 +356,7 @@ def primary_key_columns(connection, db, table):
         return set([c[0] for c in cur.fetchall()])
 
 
-# TODO: Move this into a common library.
+# TODO: Maybe put in a singer-db-utils library.
 def desired_columns(selected, table_schema):
 
     '''Return the set of column names we need to include in the SELECT.
@@ -482,7 +482,7 @@ def sync_table(connection, catalog_entry, state):
         if not stream_state.replication_key:
             yield activate_version_message
 
-
+# TODO: Maybe put in a singer-db-utils library.
 def resolve_catalog(con, catalog, state):
     '''Returns the Catalog of data we're going to sync.
 

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -528,10 +528,9 @@ def generate_messages(con, catalog, raw_state):
         selected = [k for k, v in catalog_entry.schema.properties.items()
                     if v.selected or k == catalog_entry.replication_key]
 
-        remove_unwanted_columns(selected, indexed_schema[database][table])
-        schema = Schema(
-            type='object',
-            properties=indexed_schema[database][table])
+        column_schemas = indexed_schema[database][table]
+        remove_unwanted_columns(selected, column_schemas)
+        schema = Schema(type='object', properties=column_schemas)
         columns = schema.properties.keys() # pylint: disable=no-member
         yield singer.SchemaMessage(
             stream=catalog_entry.stream,

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -491,9 +491,6 @@ def generate_messages(con, catalog, raw_state):
         state.current_stream = catalog_entry.tap_stream_id
         yield state.make_state_message()
 
-        database = catalog_entry.database
-        table = catalog_entry.table
-
         discovered_table = discovered_catalog.get_stream(catalog_entry.tap_stream_id)
         if not discovered_table:
             LOGGER.warning('Database %s table %s was selected but does not exist',
@@ -513,8 +510,8 @@ def generate_messages(con, catalog, raw_state):
             schema=out_schema.to_dict(),
             key_properties=catalog_entry.key_properties)
         with metrics.job_timer('sync_table') as timer:
-            timer.tags['database'] = database
-            timer.tags['table'] = table
+            timer.tags['database'] = catalog_entry.database
+            timer.tags['table'] = catalog_entry.table
             for message in sync_table(con, columns, catalog_entry, state):
                 yield message
     state.current_stream = None

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -360,7 +360,6 @@ def primary_key_columns(connection, db, table):
 # Maybe make it a method on Catalog or CatalogEntry.
 def desired_columns(selected, column_schemas):
 
-    selected = set(selected)
     all_columns = set()
     available = set()
     automatic = set()
@@ -501,19 +500,17 @@ def generate_messages(con, catalog, raw_state):
                            catalog_entry.database, catalog_entry.table)
         discovered_column_schemas = discovered_table.schema.properties
         
-        selected = [k for k, v in catalog_entry.schema.properties.items()
-                    if v.selected or k == catalog_entry.replication_key]
+        selected = set([k for k, v in catalog_entry.schema.properties.items()
+                        if v.selected or k == catalog_entry.replication_key])
 
         columns = desired_columns(selected, discovered_column_schemas)
-        schema = Schema(
+        out_schema = Schema(
             type='object',
             properties={col: discovered_column_schemas[col]
                         for col in columns})
-
-
         yield singer.SchemaMessage(
             stream=catalog_entry.stream,
-            schema=schema.to_dict(),
+            schema=out_schema.to_dict(),
             key_properties=catalog_entry.key_properties)
         with metrics.job_timer('sync_table') as timer:
             timer.tags['database'] = database

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -550,10 +550,10 @@ def generate_messages(con, catalog, state):
     yield state.make_state_message()
 
 
-def do_sync(con, raw_selections, raw_state):
+def do_sync(con, catalog, state):
     with con.cursor() as cur:
         cur.execute('SET time_zone="+0:00"')
-    for message in generate_messages(con, raw_selections, raw_state):
+    for message in generate_messages(con, catalog, state):
         singer.write_message(message)
 
 
@@ -582,7 +582,8 @@ def main():
     if args.discover:
         do_discover(connection)
     elif args.catalog:
-        do_sync(connection, args.catalog, args.state)
+        state = State.from_dict(args.state, args.catalog)
+        do_sync(connection, args.catalog, state)
     elif args.properties:
         catalog = Catalog.from_dict(args.properties)
         state = State.from_dict(args.state, catalog)

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -492,7 +492,7 @@ def generate_messages(con, catalog, raw_state):
     LOGGER.info('State is %s', state.make_state_message())
     if state.current_stream:
         streams = dropwhile(lambda s: s.tap_stream_id != state.current_stream, streams)
- 
+
     # Iterate over the streams in the input catalog and match each one up
     # with the same stream in the discovered catalog.
     for catalog_entry in streams:
@@ -503,7 +503,7 @@ def generate_messages(con, catalog, raw_state):
         if not discovered_table:
             LOGGER.warning('Database %s table %s was selected but does not exist',
                            catalog_entry.database, catalog_entry.table)
-        
+
         selected = set([k for k, v in catalog_entry.schema.properties.items()
                         if v.selected or k == catalog_entry.replication_key])
 
@@ -512,7 +512,10 @@ def generate_messages(con, catalog, raw_state):
             type='object',
             properties={col: discovered_table.schema.properties[col]
                         for col in columns})
-        yield singer.SchemaMessage(stream=catalog_entry.stream, schema=out_schema.to_dict(), key_properties=catalog_entry.key_properties)
+        yield singer.SchemaMessage(
+            stream=catalog_entry.stream,
+            schema=out_schema.to_dict(),
+            key_properties=catalog_entry.key_properties)
         with metrics.job_timer('sync_table') as timer:
             timer.tags['database'] = catalog_entry.database
             timer.tags['table'] = catalog_entry.table

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -405,17 +405,20 @@ def remove_unwanted_columns(selected, column_schemas):
 
     selected_but_unsupported = selected.intersection(unsupported)
     if selected_but_unsupported:
-        LOGGER.warning('Columns %s were selected but are not supported. Skipping them.',  # pylint: disable=line-too-long
-                       selected_but_unsupported)
+        LOGGER.warning(
+            'Columns %s were selected but are not supported. Skipping them.',
+            selected_but_unsupported)
 
     selected_but_nonexistent = selected.difference(all_columns)
     if selected_but_nonexistent:
-        LOGGER.warning('Columns %s were selected but do not exist.',
-                       selected_but_nonexistent)
+        LOGGER.warning(
+            'Columns %s were selected but do not exist.',
+            selected_but_nonexistent)
 
     not_selected_but_automatic = automatic.difference(selected)
     if not_selected_but_automatic:
-        LOGGER.warning('Columns %s are primary keys but were not selected. Automatically adding them.',  # pylint: disable=line-too-long
+        LOGGER.warning(
+            'Columns %s are primary keys but were not selected. Adding them.',
                        not_selected_but_automatic)
 
     keep = selected.intersection(available).union(automatic)

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -410,7 +410,8 @@ def escape(string):
     return '`' + string + '`'
 
 
-def sync_table(connection, columns, catalog_entry, state):
+def sync_table(connection, catalog_entry, state):
+    columns = list(catalog_entry.schema.properties.keys())
     if not columns:
         LOGGER.warning(
             'There are no columns selected for table %s, skipping it',
@@ -531,7 +532,7 @@ def generate_messages(con, catalog, raw_state):
         with metrics.job_timer('sync_table') as timer:
             timer.tags['database'] = catalog_entry.database
             timer.tags['table'] = catalog_entry.table
-            for message in sync_table(con, columns, catalog_entry, state):
+            for message in sync_table(con, catalog_entry, state):
                 yield message
     state.current_stream = None
     yield state.make_state_message()

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -229,7 +229,7 @@ def schema_for_column(c):
 
 def discover_catalog(connection):
     '''Returns a Catalog describing the structure of the database.'''
-    
+
     with connection.cursor() as cursor:
         if connection.db:
             cursor.execute("""

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -229,9 +229,7 @@ class TestSelectsAppropriateColumns(unittest.TestCase):
                                     'c': Schema(None, inclusion='automatic'),}}}
 
         tap_mysql.remove_unwanted_columns(selected_cols,
-                                          indexed_schema,
-                                          'some_db',
-                                          'some_table')
+                                          indexed_schema['some_db']['some_table'])
 
         self.assertEqual(indexed_schema,
                          expected_pruned_schema,

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -170,7 +170,7 @@ class TestTypeMapping(unittest.TestCase):
 class TestSelectsAppropriateColumns(unittest.TestCase):
 
     def runTest(self):
-        selected_cols = ['a', 'b', 'd']
+        selected_cols = set(['a', 'b', 'd'])
         indexed_schema = {'some_db':
                           {'some_table':
                            {'a': Schema(None, inclusion='available'),

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -171,20 +171,13 @@ class TestSelectsAppropriateColumns(unittest.TestCase):
 
     def runTest(self):
         selected_cols = set(['a', 'b', 'd'])
-        indexed_schema = {'some_db':
-                          {'some_table':
-                           {'a': Schema(None, inclusion='available'),
-                            'b': Schema(None, inclusion='unsupported'),
-                            'c': Schema(None, inclusion='automatic')}}}
+        table_schema = Schema(type='object',
+                              properties={
+                                  'a': Schema(None, inclusion='available'),
+                                  'b': Schema(None, inclusion='unsupported'),
+                                  'c': Schema(None, inclusion='automatic')})
 
-        expected_pruned_schema = {'some_db':
-                                  {'some_table':
-                                   {'a': Schema(None, inclusion='available'),
-                                    'c': Schema(None, inclusion='automatic'),}}}
-
-        got_cols = tap_mysql.desired_columns(
-            selected_cols,
-            indexed_schema['some_db']['some_table'])
+        got_cols = tap_mysql.desired_columns(selected_cols, table_schema)
 
         self.assertEqual(got_cols,
                          set(['a', 'c']),

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -167,50 +167,6 @@ class TestTypeMapping(unittest.TestCase):
             'automatic')
 
 
-class TestIndexDiscoveredSchema(unittest.TestCase):
-
-    def setUp(self):
-        con = get_test_connection()
-
-        try:
-            with con.cursor() as cur:
-                cur.execute('''
-                    CREATE TABLE tab (
-                      a INTEGER,
-                      b INTEGER)
-                ''')
-
-                self.catalog = tap_mysql.discover_catalog(con)
-        finally:
-            con.close()
-
-    def runTest(self):
-        catalog = copy.deepcopy(self.catalog)
-        print(tap_mysql.index_catalog(catalog))
-        self.assertEqual(
-            tap_mysql.index_catalog(catalog),
-            {
-                "tap_mysql_test-tab": {
-                    "b": Schema(
-                        ['null', 'integer'],
-                        selected=False,
-                        sqlDatatype='int(11)',
-                        inclusion="available",
-                        maximum=2147483647,
-                        minimum=-2147483648),
-                    "a": Schema(
-                        ['null', 'integer'],
-                        selected=False,
-                        sqlDatatype='int(11)',
-                        inclusion="available",
-                        maximum=2147483647,
-                        minimum=-2147483648),
-                }
-            },
-
-            'makes nested structure from flat discovered schemas')
-
-
 class TestSelectsAppropriateColumns(unittest.TestCase):
 
     def runTest(self):

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -190,23 +190,21 @@ class TestIndexDiscoveredSchema(unittest.TestCase):
         self.assertEqual(
             tap_mysql.index_catalog(catalog),
             {
-                "tap_mysql_test": {
-                    "tab": {
-                        "b": Schema(
-                            ['null', 'integer'],
-                            selected=False,
-                            sqlDatatype='int(11)',
-                            inclusion="available",
-                            maximum=2147483647,
-                            minimum=-2147483648),
-                        "a": Schema(
-                            ['null', 'integer'],
-                            selected=False,
-                            sqlDatatype='int(11)',
-                            inclusion="available",
-                            maximum=2147483647,
-                            minimum=-2147483648),
-                    }
+                "tap_mysql_test-tab": {
+                    "b": Schema(
+                        ['null', 'integer'],
+                        selected=False,
+                        sqlDatatype='int(11)',
+                        inclusion="available",
+                        maximum=2147483647,
+                        minimum=-2147483648),
+                    "a": Schema(
+                        ['null', 'integer'],
+                        selected=False,
+                        sqlDatatype='int(11)',
+                        inclusion="available",
+                        maximum=2147483647,
+                        minimum=-2147483648),
                 }
             },
 
@@ -262,7 +260,7 @@ class TestSchemaMessages(unittest.TestCase):
 
 def current_stream_seq(messages):
     return ''.join(
-        [m.value.get('current_stream', '_')
+        [m.value.get('current_stream', '_')[-1]
          for m in messages
          if isinstance(m, singer.StateMessage)]
     )
@@ -283,7 +281,6 @@ class TestCurrentStream(unittest.TestCase):
             stream.key_properties = []
             stream.schema.properties['val'].selected = True
             stream.stream = stream.table
-            stream.tap_stream_id = stream.table
 
     def tearDown(self):
         if self.con:
@@ -294,7 +291,7 @@ class TestCurrentStream(unittest.TestCase):
         self.assertRegexpMatches(current_stream_seq(messages), '^a+b+_+')
 
     def test_start_at_current_stream(self):
-        state = {'current_stream': 'b'}
+        state = {'current_stream': 'tap_mysql_test-b'}
         messages = list(tap_mysql.generate_messages(self.con, self.catalog, state))
         self.assertRegexpMatches(current_stream_seq(messages), '^b+_+')
 

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -182,11 +182,12 @@ class TestSelectsAppropriateColumns(unittest.TestCase):
                                    {'a': Schema(None, inclusion='available'),
                                     'c': Schema(None, inclusion='automatic'),}}}
 
-        tap_mysql.remove_unwanted_columns(selected_cols,
-                                          indexed_schema['some_db']['some_table'])
+        got_cols = tap_mysql.desired_columns(
+            selected_cols,
+            indexed_schema['some_db']['some_table'])
 
-        self.assertEqual(indexed_schema,
-                         expected_pruned_schema,
+        self.assertEqual(got_cols,
+                         set(['a', 'c']),
                          'Keep automatic as well as selected, available columns.')
 
 class TestSchemaMessages(unittest.TestCase):


### PR DESCRIPTION
Big Changes
---------------

The most significant change here is a big refactoring of `generate_messages`. It was a pretty big function, and I took a bunch of the logic related to deciding which tables and columns to grab and moved that out into its own function called `resolve_catalog`. Please see the docstring for that function for a description of what it does.

I was also able to get rid of the `index_catalog` function, now that `Catalog` has a function to find a `CatalogEntry` based on `tap_stream_id`.

Change `remove_unwanted_columns` significantly and rename to `desired_columns`. Rather than modify its input, just returns a set of desired column names.

Smaller Changes
-------------------

1. Add docstrings to several classes and functions
2. Remove several unused classes and functions
    1. `InputException`
    2. `replication_key_by_table`
    3. `primary_key_columns`
3. Changed a few functions that used to take a `CatalogEntry`, table name, and database name to only take a `CatalogEntry`. Table name and database name are properties on a `CatalogEntry` anyway.
4. Removed a few tests that are now obsolete.

Remaining
------------

There are a few things outstanding, but I'd like to get this merged in ASAP since I'll be away soon.

1. There are four functions that I think are general enough that they belong in a `singer-db-utils` library. I marked them with TODOs.
2. We could use some unit tests around `resolve_catalog`.