### PR TITLE
get all database catalogs upon discovery

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -59,8 +59,7 @@ def parse_internal_hostname(hostname):
         parts = hostname.split(":")
         if len(parts) == 3:
             return parts[0] + ":" + parts[2]
-        else:
-            return parts[0] + ":" + parts[1]
+        return parts[0] + ":" + parts[1]
 
     return hostname
 

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -236,27 +236,17 @@ def discover_catalog(connection):
     '''Returns a Catalog describing the structure of the database.'''
 
     with connection.cursor() as cursor:
-        if connection.db:
-            cursor.execute("""
-                SELECT table_schema,
-                       table_name,
-                       table_type,
-                       table_rows
-                  FROM information_schema.tables
-                 WHERE table_schema = %s""",
-                           (connection.db,))
-        else:
-            cursor.execute("""
-                SELECT table_schema,
-                       table_name,
-                       table_type,
-                       table_rows
-                  FROM information_schema.tables
-                 WHERE table_schema NOT IN (
-                          'information_schema',
-                          'performance_schema',
-                          'mysql')
-            """)
+        cursor.execute("""
+            SELECT table_schema,
+                   table_name,
+                   table_type,
+                   table_rows
+                FROM information_schema.tables
+                WHERE table_schema NOT IN (
+                        'information_schema',
+                        'performance_schema',
+                        'mysql')
+        """)
         table_info = {}
 
         for (db, table, table_type, rows) in cursor.fetchall():
@@ -269,37 +259,22 @@ def discover_catalog(connection):
 
     with connection.cursor() as cursor:
 
-        if connection.db:
-            cursor.execute("""
-                SELECT table_schema,
-                       table_name,
-                       column_name,
-                       data_type,
-                       character_maximum_length,
-                       numeric_precision,
-                       numeric_scale,
-                       column_type,
-                       column_key
-                  FROM information_schema.columns
-                 WHERE table_schema = %s""",
-                           (connection.db,))
-        else:
-            cursor.execute("""
-                SELECT table_schema,
-                       table_name,
-                       column_name,
-                       data_type,
-                       character_maximum_length,
-                       numeric_precision,
-                       numeric_scale,
-                       column_type,
-                       column_key
-                  FROM information_schema.columns
-                 WHERE table_schema NOT IN (
-                          'information_schema',
-                          'performance_schema',
-                          'mysql')
-            """)
+        cursor.execute("""
+            SELECT table_schema,
+                   table_name,
+                   column_name,
+                   data_type,
+                   character_maximum_length,
+                   numeric_precision,
+                   numeric_scale,
+                   column_type,
+                   column_key
+                FROM information_schema.columns
+                WHERE table_schema NOT IN (
+                        'information_schema',
+                        'performance_schema',
+                        'mysql')
+        """)
 
         columns = []
         rec = cursor.fetchone()


### PR DESCRIPTION
Presently, if a `database_name` is provided in the config, the Tap uses that database name when creating the connection -- this is appropriate. The Tap is _also_ using that database name to only discover tables under that database catalog. This behavior is undesirable. The Tap should discover any databases it can, not just the one used for the connection configuration.