### PR TITLE
SSL support

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -83,7 +83,6 @@ def open_connection(config):
             return conn
         except: # pylint: disable=bare-except
             LOGGER.error("SSL connection failed")
-            pass
 
     try:
         LOGGER.info("Attempting connection")

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -50,7 +50,7 @@ READ_TIMEOUT_SECONDS = 3600
 
 
 def open_connection_has_ca(args):
-    args["ssl"] = {"ca": config["ssl_ca"]}
+    args["ssl"] = {"ca": args["ssl_ca"]}
     return pymysql.connect(**args)
 
 
@@ -80,14 +80,14 @@ def open_connection(config):
 
     if config.get("ssl_ca"):
         try:
-            return open_connection_has_ca(config)
-        except:
+            return pymysql.connect(ssl={"ca": config["ssl_ca"]}, **args)
+        except: # pylint: disable=bare-except
             pass
 
     if config.get("ssl", False):
         try:
             return open_connection_ssl(config)
-        except:
+        except: # pylint: disable=bare-except
             pass
 
     return pymysql.connect(**args)

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -39,7 +39,7 @@ Column = collections.namedtuple('Column', [
 REQUIRED_CONFIG_KEYS = [
     'host',
     'port',
-    'username',
+    'user',
     'password'
 ]
 


### PR DESCRIPTION
Since we don't validate, the normal code paths for enabling SSL won't work. This sets up the SSL context properly for SSL connections that don't have a ca set. The `ssl_ca` option is a placeholder more than a useful feature. It will need to be the path to a ca file to be used for the SSL handshake, but there's no infrastructure for the front or back end to support this yet. The idea is that if that ca is set, we will try to use it and fall back to non-verified ssl. If non-verified ssl were to fail, it falls back to no ssl. If no ssl fails, the job fails.

I've tested the 50 SSL mysql integrations that don't require SSH tunnels. Of them:
* 12 are not reachable on prod or through testing
* 7 do not have SSL enabled on the server
* 31 connect successfully