### PR TITLE
make rep value into date obj for querying

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -52,6 +52,7 @@ READ_TIMEOUT_SECONDS = 3600
 # We need to hold onto this for self-signed SSL
 match_hostname = ssl.match_hostname
 
+pymysql.converters.conversions[pendulum.Pendulum] = pymysql.converters.escape_datetime
 
 def parse_internal_hostname(hostname):
     # special handling for google cloud
@@ -459,13 +460,16 @@ def sync_table(connection, catalog_entry, state):
         if stream_state.replication_key_value is not None:
             key = stream_state.replication_key
             value = stream_state.replication_key_value
+            if catalog_entry.schema.properties[stream_state.replication_key].format == 'date-time':
+                value = pendulum.parse(value)
             select += ' WHERE `{}` >= %(replication_key_value)s ORDER BY `{}` ASC'.format(key, key)
             params['replication_key_value'] = value
         elif stream_state.replication_key is not None:
             key = stream_state.replication_key
             select += ' ORDER BY `{}` ASC'.format(key)
 
-        LOGGER.info('Running %s', select)
+        query_string = cursor.mogrify(select, params)
+        LOGGER.info('Running %s', query_string)
         cursor.execute(select, params)
         row = cursor.fetchone()
         rows_saved = 0

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -494,7 +494,7 @@ def sync_table(connection, catalog_entry, state):
                 row_to_persist = ()
                 for elem in row:
                     if isinstance(elem, datetime.datetime):
-                        row_to_persist += (pendulum.instance(elem).to_iso8601_string(),)
+                        row_to_persist += (elem.isoformat(),)
                     else:
                         row_to_persist += (elem,)
                 rec = dict(zip(columns, row_to_persist))


### PR DESCRIPTION
- determine if replication key is a date-time based on the schema. if so, parse it into a date object (using pendulum) so that pymysql can use the [proper date format](https://dev.mysql.com/doc/refman/5.6/en/date-and-time-literals.html) for querying
- [mogrify](http://pymysql.readthedocs.io/en/latest/modules/cursors.html#pymysql.cursors.Cursor.mogrify) the `SELECT` query before logging it
- also fixes a formatting issue that caused date-time strings with years before `1000` to fail JSON Schema validation

```
INFO Running SELECT `animal`,`updated_at`,`id` FROM `some_db`.`some_table` WHERE `updated_at` >= '2017-07-24 16:30:43' ORDER BY `updated_at` ASC
```

Note: we need to take [special care](https://github.com/singer-io/tap-mysql/pull/29/files#diff-1463e5d5f4c92b29cdaace9a7519ea79R55) to tell pymysql how to handle the pendulum date time https://pendulum.eustace.io/docs/#limitations