### PR TITLE
always use +00:00 offset for date-times

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -494,7 +494,7 @@ def sync_table(connection, catalog_entry, state):
                 row_to_persist = ()
                 for elem in row:
                     if isinstance(elem, datetime.datetime):
-                        row_to_persist += (elem.isoformat(),)
+                        row_to_persist += (elem.isoformat() + '+00:00',)
                     else:
                         row_to_persist += (elem,)
                 rec = dict(zip(columns, row_to_persist))


### PR DESCRIPTION
The [RFC 3339](https://tools.ietf.org/html/rfc3339) spec (used by JSON Schema for `date-time` formatted string validation) dictates that date-times should always include an offset from UTC. There are some MySQL time data types (like `DATETIME`) for which the timezone/offset is undefined.

This change makes it so that we always simply use UTC for date-times. Clients of this Tap should recognize that the UTC assumption is made when no offset is available.