### PR TITLE
add support for `BIT`, `DATE`, and `TIME` sql types

### DIFF
--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -59,7 +59,10 @@ class TestTypeMapping(unittest.TestCase):
             c_bigint BIGINT,
             c_float FLOAT,
             c_double DOUBLE,
-            c_bit BIT(4)
+            c_bit BIT(4),
+            c_date DATE,
+            c_time TIME,
+            c_year YEAR
             )''')
 
             catalog = discover_catalog(con)
@@ -162,9 +165,31 @@ class TestTypeMapping(unittest.TestCase):
                                 sqlDatatype='double'))
 
     def test_bit(self):
-        self.assertEqual(self.schema.properties['c_bit'].inclusion,
-                         'unsupported')
+        self.assertEqual(self.schema.properties['c_bit'],
+                         Schema(['null', 'boolean'],
+                                selected=False,
+                                inclusion='available',
+                                sqlDatatype='bit(4)'))
 
+    def test_date(self):
+        self.assertEqual(self.schema.properties['c_date'],
+                         Schema(['null', 'string'],
+                                format='date-time',
+                                selected=False,
+                                inclusion='available',
+                                sqlDatatype='date'))
+
+    def test_time(self):
+        self.assertEqual(self.schema.properties['c_time'],
+                         Schema(['null', 'string'],
+                                format='date-time',
+                                selected=False,
+                                inclusion='available',
+                                sqlDatatype='time'))
+
+    def test_year(self):
+        self.assertEqual(self.schema.properties['c_year'].inclusion,
+                         'unsupported')
     def test_pk(self):
         self.assertEqual(
             self.schema.properties['c_pk'].inclusion,


### PR DESCRIPTION
This branch adds support for replicating `BIT`, `DATE`, and `TIME` typed fields.

`BIT` - persisted as a boolean value. `b'0'` is `false`, anything else is `true`
`DATE` - persisted as a `date-time` formatted string, with a time of `00:00:00` and a `+00:00` offset from UTC
`TIME` - persisted as a delta from epoch, also formatted as a `date-time` string. e.g. `11:28:30` would become `1970-01-01T11:28:30+00:00`

input:

```
mysql> describe unsupported_types;
+-----------+---------------+------+-----+---------+----------------+
| Field     | Type          | Null | Key | Default | Extra          |
+-----------+---------------+------+-----+---------+----------------+
| id        | int(11)       | NO   | PRI | NULL    | auto_increment |
| c_bit     | bit(1)        | YES  |     | NULL    |                |
| c_time    | time          | YES  |     | NULL    |                |
| c_date    | date          | YES  |     | NULL    |                |
+-----------+---------------+------+-----+---------+----------------+
```

```
mysql> select id, cast(c_bit as unsigned) as c_bit, c_time, c_date from unsupported_types;
+----+-------+----------+------------+
| id | c_bit | c_time   | c_date     |
+----+-------+----------+------------+
|  1 |     1 | 11:28:30 | 2017-08-02 |
|  2 |     0 | 00:00:00 | 2017-08-03 |
+----+-------+----------+------------+
2 rows in set (0.00 sec)
```

output:

```
{
  "key_properties": [
    "id"
  ],
  "schema": {
    "properties": {
      "c_date": {
        "format": "date-time",
        "type": [
          "null",
          "string"
        ],
        "sqlDatatype": "date",
        "inclusion": "available",
        "selected": false
      },
      "c_time": {
        "format": "date-time",
        "type": [
          "null",
          "string"
        ],
        "sqlDatatype": "time",
        "inclusion": "available",
        "selected": false
      },
      "c_bit": {
        "type": [
          "null",
          "boolean"
        ],
        "sqlDatatype": "bit(1)",
        "inclusion": "available",
        "selected": false
      },
      "id": {
        "selected": false,
        "inclusion": "automatic",
        "maximum": 2147483647,
        "minimum": -2147483648,
        "sqlDatatype": "int(11)",
        "type": [
          "null",
          "integer"
        ]
      }
    },
    "type": "object"
  },
  "stream": "unsupported_types",
  "type": "SCHEMA"
}
```

```
{
  "record": {
    "c_date": "2017-08-02T00:00:00+00:00",
    "c_time": "1970-01-01T11:28:30+00:00",
    "c_bit": true,
    "id": 1
  },
  "version": 1501701452275,
  "stream": "unsupported_types",
  "type": "RECORD"
}
{
  "record": {
    "c_date": "2017-08-03T00:00:00+00:00",
    "c_time": "1970-01-01T00:00:00+00:00",
    "c_bit": false,
    "id": 2
  },
  "version": 1501701452275,
  "stream": "unsupported_types",
  "type": "RECORD"
}
```