### PR TITLE
Feature/log table engine

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -436,16 +436,24 @@ def get_engine(connection, catalog_entry):
         row = cursor.fetchone()
 
         if row is None:
-            raise Exception("Attempting to sync table {}.{} but it does not exist".format(catalog_entry.database, catalog_entry.table))
+            raise Exception("Attempting to sync table {}.{} but it does not exist".format(
+                catalog_entry.database,
+                catalog_entry.table))
         else:
             return row[0]
 
-def sync_table(connection, catalog_entry, state):
+def log_engine(connection, catalog_entry):
     if catalog_entry.is_view:
-        LOGGER.info("Beginning sync for view {}.{}".format(catalog_entry.database, catalog_entry.table))
+        LOGGER.info("Beginning sync for view %s.%s", catalog_entry.database, catalog_entry.table)
     else:
         engine = get_engine(connection, catalog_entry)
-        LOGGER.info("Beginning sync for {} table {}.{}".format(engine, catalog_entry.database, catalog_entry.table))
+        LOGGER.info("Beginning sync for %s table %s.%s",
+                    engine,
+                    catalog_entry.database,
+                    catalog_entry.table)
+
+def sync_table(connection, catalog_entry, state):
+    log_engine(connection, catalog_entry)
 
     columns = list(catalog_entry.schema.properties.keys())
     if not columns:

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -572,6 +572,7 @@ def resolve_catalog(con, catalog, state):
             database=catalog_entry.database,
             table=catalog_entry.table,
             replication_key=catalog_entry.replication_key,
+            is_view=catalog_entry.is_view,
             schema=Schema(
                 type='object',
                 properties={col: discovered_table.schema.properties[col]


### PR DESCRIPTION
Add logging at the beginning of `sync_table` to inform what engine the table is using. In the case of a view, simply log that it is a view.