### PR TITLE
use WHERE clause in incremental SELECT stmt even when rep-key isn't date-time

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -484,10 +484,10 @@ def sync_table(connection, catalog_entry, state):
         if replication_key_value is not None:
             if catalog_entry.schema.properties[replication_key].format == 'date-time':
                 replication_key_value = pendulum.parse(replication_key_value)
-                select += ' WHERE `{}` >= %(replication_key_value)s ORDER BY `{}` ASC'.format(
-                    replication_key,
-                    replication_key)
-                params['replication_key_value'] = replication_key_value
+            select += ' WHERE `{}` >= %(replication_key_value)s ORDER BY `{}` ASC'.format(
+                replication_key,
+                replication_key)
+            params['replication_key_value'] = replication_key_value
         elif replication_key is not None:
             select += ' ORDER BY `{}` ASC'.format(replication_key)
 

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -484,6 +484,7 @@ def sync_table(connection, catalog_entry, state):
         if replication_key_value is not None:
             if catalog_entry.schema.properties[replication_key].format == 'date-time':
                 replication_key_value = pendulum.parse(replication_key_value)
+
             select += ' WHERE `{}` >= %(replication_key_value)s ORDER BY `{}` ASC'.format(
                 replication_key,
                 replication_key)


### PR DESCRIPTION
We were accidentally only adding a `WHERE` clause to select-based incremental replication when the replication key was a date-time. This change fixes the indentation and resolves this logical bug -- now we'll properly add the `WHERE` clause regardless of the key's type or format. I also expanded the unit tests around incremental replication to help prevent regressions.