### PR TITLE
tinyint(1) should be boolean, not integer

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -192,22 +192,23 @@ def build_state(raw_state, catalog):
 
 def schema_for_column(c):
     '''Returns the Schema object for the given Column.'''
-    t = c.data_type
+    data_type = c.data_type.lower()
+    column_type = c.column_type.lower()
 
     inclusion = 'available'
     # We want to automatically include all primary key columns
-    if c.column_key == 'PRI':
+    if c.column_key.lower() == 'pri':
         inclusion = 'automatic'
 
     result = Schema(inclusion=inclusion, selected=True)
     result.sqlDatatype = c.column_type
 
-    if t == 'bit' or c.column_type == 'tinyint(1)':
+    if data_type == 'bit' or column_type == 'tinyint(1)':
         result.type = ['null', 'boolean']
 
-    elif t in BYTES_FOR_INTEGER_TYPE:
+    elif data_type in BYTES_FOR_INTEGER_TYPE:
         result.type = ['null', 'integer']
-        bits = BYTES_FOR_INTEGER_TYPE[t] * 8
+        bits = BYTES_FOR_INTEGER_TYPE[data_type] * 8
         if 'unsigned' in c.column_type:
             result.minimum = 0
             result.maximum = 2 ** bits
@@ -215,34 +216,34 @@ def schema_for_column(c):
             result.minimum = 0 - 2 ** (bits - 1)
             result.maximum = 2 ** (bits - 1) - 1
 
-    elif t in FLOAT_TYPES:
+    elif data_type in FLOAT_TYPES:
         result.type = ['null', 'number']
 
-    elif t == 'decimal':
+    elif data_type == 'decimal':
         result.type = ['null', 'number']
         result.exclusiveMaximum = True
         result.maximum = 10 ** (c.numeric_precision - c.numeric_scale)
         result.multipleOf = 10 ** (0 - c.numeric_scale)
-        if 'unsigned' in c.column_type:
+        if 'unsigned' in column_type:
             result.minimum = 0
         else:
             result.exclusiveMinimum = True
             result.minimum = -10 ** (c.numeric_precision - c.numeric_scale)
         return result
 
-    elif t in STRING_TYPES:
+    elif data_type in STRING_TYPES:
         result.type = ['null', 'string']
         result.maxLength = c.character_maximum_length
 
-    elif t in DATETIME_TYPES:
+    elif data_type in DATETIME_TYPES:
         result.type = ['null', 'string']
         result.format = 'date-time'
 
     else:
         result = Schema(None,
                         inclusion='unsupported',
-                        sqlDatatype=c.column_type,
-                        description='Unsupported column type {}'.format(c.column_type))
+                        sqlDatatype=column_type,
+                        description='Unsupported column type {}'.format(column_type))
     return result
 
 
@@ -388,7 +389,7 @@ def get_stream_version(tap_stream_id, state):
 def row_to_singer_record(catalog_entry, version, row, columns):
     row_to_persist = ()
     for idx, elem in enumerate(row):
-        column_type = catalog_entry.schema.properties[columns[idx]].type
+        property_type = catalog_entry.schema.properties[columns[idx]].type
         if isinstance(elem, datetime.datetime):
             row_to_persist += (elem.isoformat() + '+00:00',)
 
@@ -405,7 +406,7 @@ def row_to_singer_record(catalog_entry, version, row, columns):
             boolean_representation = elem != b'\x00'
             row_to_persist += (boolean_representation,)
 
-        elif 'boolean' in column_type or column_type == 'boolean':
+        elif 'boolean' in property_type or property_type == 'boolean':
             # for TINYINT(1) value, treat 0 as False and anything else as True
             boolean_representation = elem != 0
             row_to_persist += (boolean_representation,)

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -54,6 +54,7 @@ class TestTypeMapping(unittest.TestCase):
             c_decimal_2_unsigned DECIMAL(5, 2) UNSIGNED,
             c_decimal_2 DECIMAL(11, 2),
             c_tinyint TINYINT,
+            c_tinyint_1 TINYINT(1),
             c_smallint SMALLINT,
             c_mediumint MEDIUMINT,
             c_int INT,
@@ -110,8 +111,16 @@ class TestTypeMapping(unittest.TestCase):
                          Schema(['null', 'integer'],
                                 selected=FIELDS_SELECTED_BY_DEFAULT,
                                 sqlDatatype='tinyint(4)',
-                                inclusion='available', minimum=-128,
+                                inclusion='available',
+                                minimum=-128,
                                 maximum=127))
+
+    def test_tinyint_1(self):
+        self.assertEqual(self.schema.properties['c_tinyint_1'],
+                         Schema(['null', 'boolean'],
+                                selected=FIELDS_SELECTED_BY_DEFAULT,
+                                sqlDatatype='tinyint(1)',
+                                inclusion='available'))
 
     def test_smallint(self):
         self.assertEqual(self.schema.properties['c_smallint'],


### PR DESCRIPTION
We had been emitting integer output for source columns of type `TINYINT(1)`. Boolean is more appropriate.

From [MySQL docs](https://dev.mysql.com/doc/refman/5.7/en/numeric-type-overview.html):

```
BOOL, BOOLEAN - These types are synonyms for TINYINT(1). A value of zero is considered false. Nonzero values are considered true
```

Functional test:

source data (note: BIT vals not properly displayed in mysql output)
```
mysql> describe bools_abound;
+-------------+------------+------+-----+---------+-------+
| Field       | Type       | Null | Key | Default | Extra |
+-------------+------------+------+-----+---------+-------+
| c_tinyint_4 | tinyint(4) | YES  |     | NULL    |       |
| c_tinyint_1 | tinyint(1) | YES  |     | NULL    |       |
| c_bit       | bit(1)     | YES  |     | NULL    |       |
+-------------+------------+------+-----+---------+-------+
3 rows in set (0.00 sec)

mysql> select * from bools_abound;
+-------------+-------------+-------+
| c_tinyint_4 | c_tinyint_1 | c_bit |
+-------------+-------------+-------+
|           0 |           0 |       |
|           1 |           1 |      |
|         127 |         127 |      |
|        -127 |        -127 |      |
+-------------+-------------+-------+
4 rows in set (0.00 sec)
```

without change (c_tinyint_1 is output as integer):
```
{"stream": "bools_abound", "type": "SCHEMA", "key_properties": null, "schema": {"properties": {"c_bit": {"sqlDatatype": "bit(1)", "selected": true, "type": ["null", "boolean"], "inclusion": "available"}, "c_tinyint_4": {"selected": true, "maximum": 127, "type": ["null", "integer"], "sqlDatatype": "tinyint(4)", "minimum": -128, "inclusion": "available"}, "c_tinyint_1": {"selected": true, "maximum": 127, "type": ["null", "integer"], "sqlDatatype": "tinyint(1)", "minimum": -128, "inclusion": "available"}}, "type": "object"}}

{"record": {"c_bit": false, "c_tinyint_4": 0, "c_tinyint_1": 0}, "stream": "bools_abound", "type": "RECORD", "version": 1506458187981}
{"record": {"c_bit": true, "c_tinyint_4": 1, "c_tinyint_1": 1}, "stream": "bools_abound", "type": "RECORD", "version": 1506458187981}
{"record": {"c_bit": true, "c_tinyint_4": 127, "c_tinyint_1": 127}, "stream": "bools_abound", "type": "RECORD", "version": 1506458187981}
{"record": {"c_bit": true, "c_tinyint_4": -127, "c_tinyint_1": -127}, "stream": "bools_abound", "type": "RECORD", "version": 1506458187981}
```

with change:
```
{"schema": {"type": "object", "properties": {"c_tinyint_1": {"inclusion": "available", "sqlDatatype": "tinyint(1)", "selected": true, "type": ["null", "boolean"]}, "c_tinyint_4": {"sqlDatatype": "tinyint(4)", "minimum": -128, "inclusion": "available", "selected": true, "type": ["null", "integer"], "maximum": 127}, "c_bit": {"inclusion": "available", "sqlDatatype": "bit(1)", "selected": true, "type": ["null", "boolean"]}}}, "stream": "bools_abound", "type": "SCHEMA", "key_properties": null}

{"version": 1506458119460, "record": {"c_tinyint_1": false, "c_tinyint_4": 0, "c_bit": false}, "stream": "bools_abound", "type": "RECORD"}
{"version": 1506458119460, "record": {"c_tinyint_1": true, "c_tinyint_4": 1, "c_bit": true}, "stream": "bools_abound", "type": "RECORD"}
{"version": 1506458119460, "record": {"c_tinyint_1": true, "c_tinyint_4": 127, "c_bit": true}, "stream": "bools_abound", "type": "RECORD"}
{"version": 1506458119460, "record": {"c_tinyint_1": true, "c_tinyint_4": -127, "c_bit": true}, "stream": "bools_abound", "type": "RECORD"}
```