### PR TITLE
treat `tinyint(1) unsigned` column as boolean

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -203,7 +203,7 @@ def schema_for_column(c):
     result = Schema(inclusion=inclusion, selected=True)
     result.sqlDatatype = c.column_type
 
-    if data_type == 'bit' or column_type == 'tinyint(1)':
+    if data_type == 'bit' or column_type.startswith('tinyint(1)'):
         result.type = ['null', 'boolean']
 
     elif data_type in BYTES_FOR_INTEGER_TYPE:

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -55,6 +55,7 @@ class TestTypeMapping(unittest.TestCase):
             c_decimal_2 DECIMAL(11, 2),
             c_tinyint TINYINT,
             c_tinyint_1 TINYINT(1),
+            c_tinyint_1_unsigned TINYINT(1) UNSIGNED,
             c_smallint SMALLINT,
             c_mediumint MEDIUMINT,
             c_int INT,
@@ -120,6 +121,13 @@ class TestTypeMapping(unittest.TestCase):
                          Schema(['null', 'boolean'],
                                 selected=FIELDS_SELECTED_BY_DEFAULT,
                                 sqlDatatype='tinyint(1)',
+                                inclusion='available'))
+
+    def test_tinyint_1_unsigned(self):
+        self.assertEqual(self.schema.properties['c_tinyint_1_unsigned'],
+                         Schema(['null', 'boolean'],
+                                selected=FIELDS_SELECTED_BY_DEFAULT,
+                                sqlDatatype='tinyint(1) unsigned',
                                 inclusion='available'))
 
     def test_smallint(self):


### PR DESCRIPTION
In https://github.com/singer-io/tap-mysql/pull/38 I made it so that the tap treats `TINYINT(1)` as boolean when it emits a schema for such a column. I neglected to account for `TINYINT(1) UNSIGNED`, so this PR addresses that case.