### PR TITLE
set max value for unsigned ints to 2^bits - 1

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -211,7 +211,7 @@ def schema_for_column(c):
         bits = BYTES_FOR_INTEGER_TYPE[data_type] * 8
         if 'unsigned' in c.column_type:
             result.minimum = 0
-            result.maximum = 2 ** bits
+            result.maximum = 2 ** bits - 1
         else:
             result.minimum = 0 - 2 ** (bits - 1)
             result.maximum = 2 ** (bits - 1) - 1

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -60,6 +60,7 @@ class TestTypeMapping(unittest.TestCase):
             c_mediumint MEDIUMINT,
             c_int INT,
             c_bigint BIGINT,
+            c_bigint_unsigned BIGINT(20) UNSIGNED,
             c_float FLOAT,
             c_double DOUBLE,
             c_bit BIT(4),
@@ -166,6 +167,15 @@ class TestTypeMapping(unittest.TestCase):
                                 inclusion='available',
                                 minimum=-9223372036854775808,
                                 maximum=9223372036854775807))
+
+    def test_bigint_unsigned(self):
+        self.assertEqual(self.schema.properties['c_bigint_unsigned'],
+                         Schema(['null', 'integer'],
+                                selected=FIELDS_SELECTED_BY_DEFAULT,
+                                sqlDatatype='bigint(20) unsigned',
+                                inclusion='available',
+                                minimum=0,
+                                maximum=18446744073709551615))
 
     def test_float(self):
         self.assertEqual(self.schema.properties['c_float'],


### PR DESCRIPTION
We had been incorrectly setting the (inclusive) maximum for unsigned integer types to be 2^bits, but it should actually be 2^bits - 1. This page shows the min/max values for signed/unsigned integer types in MySQL: https://dev.mysql.com/doc/refman/5.5/en/integer-types.html