### PR TITLE
catch error when setting a mysql session var fails

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -682,9 +682,21 @@ def main_impl():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
     connection = open_connection(args.config)
     with connection.cursor() as cur:
-        cur.execute('SET @@session.time_zone="+0:00"')
-        cur.execute('SET @@session.wait_timeout=2700')
-        cur.execute('SET @@session.innodb_lock_wait_timeout=2700')
+        try:
+            cur.execute('SET @@session.time_zone="+0:00"')
+        except pymysql.err.InternalError as e:
+            code, msg = e.args
+            LOGGER.warn('Could not set session.time_zone. Code: %s. Message: %s', code, msg)
+        try:
+            cur.execute('SET @@session.wait_timeout=2700')
+        except pymysql.err.InternalError as e:
+            code, msg = e.args
+            LOGGER.warn('Could not set session.wait_timeout. Code: %s. Message: %s', code, msg)
+        try:
+            cur.execute('SET @@session.innodb_lock_wait_timeout=2700')
+        except pymysql.err.InternalError as e:
+            code, msg = e.args
+            LOGGER.warn('Could not set session.time_zone. Code: %s. Message: %s', code, msg)
     log_server_params(connection)
     if args.discover:
         do_discover(connection)

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -703,6 +703,9 @@ def main_impl():
                 'Could not set session.innodb_lock_wait_timeout. Error: ({}) {}'.format(*e.args)
                 )
 
+    if warnings:
+        LOGGER.info(("Encountered non-fatal errors when configuring MySQL session that could "
+                     "impact performance:"))
     for w in warnings:
         LOGGER.warning(w)
 


### PR DESCRIPTION
Presently, the tap will fail if an error is encountered attempting to set a MySQL session variable. These session vars aren't strictly necessary for the tap to function, and different server configurations might not support setting them. This change makes it so that the tap logs a warning if one of the session vars can't be set, but it will continue past such errors.