### PR TITLE
don't set a col to be a key_property if it's unsupported

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -340,7 +340,11 @@ def discover_catalog(connection):
                 metadata=md,
                 tap_stream_id=table_schema + '-' + table_name,
                 schema=schema)
-            key_properties = [c.column_name for c in cols if c.column_key == 'PRI']
+            column_is_key_prop = lambda c, s: (
+                c.column_key == 'PRI' and
+                s.properties[c.column_name].inclusion != 'unsupported'
+            )
+            key_properties = [c.column_name for c in cols if column_is_key_prop(c, schema)]
             if key_properties:
                 entry.key_properties = key_properties
 


### PR DESCRIPTION
Presently, the tap will put a primary key field in its stream's `key_properties` array. This should not happen if the column has an unsupported data type (i.e., if the field has an `unsupported` inclusion). If the field is unsupported, the tap will not emit it. If it's a key_property, downstream consumers will expect it to be present in every record. The solution is to exclude the unsupported column from records and to exclude it from `key_properties`.