### PR TITLE
Use the utf8 charset option when forming pymysql connection

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -88,6 +88,7 @@ def open_connection(config):
         "cursorclass": pymysql.cursors.SSCursor,
         "connect_timeout": CONNECT_TIMEOUT_SECONDS,
         "read_timeout": READ_TIMEOUT_SECONDS,
+        "charset": "utf8",
     }
 
     if config.get("database"):

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -15,6 +15,7 @@ def get_test_connection():
     creds['host'] = os.environ.get('SINGER_TAP_MYSQL_TEST_DB_HOST')
     creds['user'] = os.environ.get('SINGER_TAP_MYSQL_TEST_DB_USER')
     creds['password'] = os.environ.get('SINGER_TAP_MYSQL_TEST_DB_PASSWORD')
+    creds['charset'] = 'utf8'
     if not creds['password']:
         del creds['password']
 


### PR DESCRIPTION
Set the [`charset` option](http://pymysql.readthedocs.io/en/latest/modules/connections.html?highlight=charset) when forming a db connection.