### PR TITLE
use backoff to retry forming db connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ or
 $ git clone git@github.com:singer-io/tap-mysql.git
 $ cd tap-mysql
 $ mkvirtualenv -p python3 tap-mysql
-$ python setup.py install
+$ python install .
 ```
 
 ### Have a source database

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,9 @@ setup(name='tap-mysql',
       install_requires=[
           'attrs==16.3.0',
           'pendulum==1.2.0',
-          'singer-python==4.0.0',
+          'singer-python==4.0.3',
           'PyMySQL==0.7.11',
+          'backoff==1.3.2',
       ],
       entry_points='''
           [console_scripts]

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -147,7 +147,7 @@ def open_connection(config):
         return conn
 
     LOGGER.info("Attempting connection without SSL")
-    conn = pymysql.Connection(defer_connect= True, **args)
+    conn = pymysql.Connection(defer_connect=True, **args)
     connect_with_backoff(conn)
     return conn
 


### PR DESCRIPTION
- uses [`backoff`](https://pypi.python.org/pypi/backoff) decorator for retrying `connect()`
- five retries over ~20 seconds
- tested fully working connection, connection that initially failed, and fully failing connection