### PR TITLE
Feature/refactor sync strategies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ develop-eggs/
 dist/
 downloads/
 eggs/
-.eggs/ lib/
+.eggs/
+lib/
 lib64/
 parts/
 sdist/

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,7 @@ develop-eggs/
 dist/
 downloads/
 eggs/
-.eggs/
-lib/
+.eggs/ lib/
 lib64/
 parts/
 sdist/
@@ -102,3 +101,5 @@ ENV/
 
 # Emacs
 .tramp_history
+
+config.json

--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,4 @@ dependencies:
 
 test:
   post:
-    - pylint tap_mysql -d C,W,unexpected-keyword-arg
+    - pylint tap_mysql -d C,W,unexpected-keyword-arg,duplicate-code

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,11 @@ setup(name='tap-mysql',
           'singer-python==5.0.4',
           'PyMySQL==0.7.11',
           'backoff==1.3.2',
+          'mysql-replication==0.18',
       ],
       entry_points='''
           [console_scripts]
           tap-mysql=tap_mysql:main
       ''',
-      packages=['tap_mysql'],
+      packages=['tap_mysql', 'tap_mysql.sync_strategies'],
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(name='tap-mysql',
           'singer-python==5.0.4',
           'PyMySQL==0.7.11',
           'backoff==1.3.2',
-          'mysql-replication==0.18',
       ],
       entry_points='''
           [console_scripts]

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=missing-docstring,not-an-iterable,too-many-locals,too-many-arguments,invalid-name
+# pylint: disable=missing-docstring,not-an-iterable,too-many-locals,too-many-arguments,invalid-name,duplicate-code
 
 import datetime
 import collections

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -557,8 +557,8 @@ def generate_messages(con, catalog, state):
             elif replication_method == 'FULL_TABLE':
                 for message in full_table.sync_table(con, catalog_entry, state):
                     yield message
-                else:
-                    raise Exception("only INCREMENTAL and FULL TABLE replication methods are supported")
+            else:
+                raise Exception("only INCREMENTAL and FULL TABLE replication methods are supported")
 
     # if we get here, we've finished processing all the streams, so clear
     # currently_syncing from the state and emit a state message.

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=too-many-arguments,duplicate-code
 
 import copy
 import datetime

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import singer
+
+import tap_mysql.sync_strategies.common as common
+
+def sync_table(connection, catalog, state):
+    columns = common.generate_column_list(catalog)
+
+    if not columns:
+        LOGGER.warning(
+            'There are no columns selected for table %s, skipping it',
+            catalog.table)
+        return
+
+    bookmark_is_empty = state.get('bookmarks', {}).get(catalog.tap_stream_id) is None
+
+
+    stream_version = common.get_stream_version(catalog.tap_stream_id, state)
+    state = singer.write_bookmark(state,
+                                  catalog.tap_stream_id,
+                                  'version',
+                                  stream_version)
+
+    activate_version_message = singer.ActivateVersionMessage(
+        stream=catalog.stream,
+        version=stream_version
+    )
+
+    # If there is no bookmark at all for this stream, assume it is the
+    # very first replication. Emity an ACTIVATE_VERSION message at the
+    # beginning so the recors show up right away.
+    if bookmark_is_empty:
+       yield activate_version_message
+
+    with connection.cursor() as cursor:
+        select = common.generate_select(catalog, columns)
+        select += ' ORDER BY `{}` ASC'.format(replication_key)
+
+        params = {}
+
+        common.sync_query(cursor, catalog, state, select, params)
+
+    # Clear the stream's version from the state so that subsequent invocations will
+    # emit a distinct stream version.
+    state = singer.write_bookmark(state, catalog_entry.tap_stream_id, 'version', None)
+
+    yield activate_version_message
+    yield singer.StateMessage(value=copy.deepcopy(state))

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=duplicate-code
 
 import copy
 import singer

--- a/tap_mysql/sync_strategies/incremental.py
+++ b/tap_mysql/sync_strategies/incremental.py
@@ -1,51 +1,61 @@
 #!/usr/bin/env python3
 
+import pendulum
 import singer
 
 import tap_mysql.sync_strategies.common as common
 
-def sync_table(connection, catalog, state):
-    columns = common.generate_column_list(catalog)
+LOGGER = singer.get_logger()
+
+def sync_table(connection, catalog_entry, state):
+    columns = common.generate_column_list(catalog_entry)
 
     if not columns:
         LOGGER.warning(
             'There are no columns selected for table %s, skipping it',
-            catalog.table)
+            catalog_entry.table)
         return
 
     replication_key_value = singer.get_bookmark(state,
-                                                catalog.tap_stream_id,
+                                                catalog_entry.tap_stream_id,
                                                 'replication_key_value')
 
     replication_key = singer.get_bookmark(state,
-                                          catalog.tap_stream_id,
+                                          catalog_entry.tap_stream_id,
                                           'replication_key')
 
-    stream_version = common.get_stream_version(catalog.tap_stream_id, state)
+    stream_version = common.get_stream_version(catalog_entry.tap_stream_id, state)
     state = singer.write_bookmark(state,
-                                  catalog.tap_stream_id,
+                                  catalog_entry.tap_stream_id,
                                   'version',
                                   stream_version)
 
     yield singer.ActivateVersionMessage(
-        stream=catalog.stream,
+        stream=catalog_entry.stream,
         version=stream_version
     )
 
     with connection.cursor() as cursor:
-        select = common.generate_select(catalog, columns)
+        select_sql = common.generate_select_sql(catalog_entry, columns)
         params = {}
 
         if replication_key_value is not None:
-            if catalog.schema.properties[replication_key].format == 'date-time':
+            if catalog_entry.schema.properties[replication_key].format == 'date-time':
                 replication_key_value = pendulum.parse(replication_key_value)
 
-            select += ' WHERE `{}` >= %(replication_key_value)s ORDER BY `{}` ASC'.format(
+            select_sql += ' WHERE `{}` >= %(replication_key_value)s ORDER BY `{}` ASC'.format(
                 replication_key,
                 replication_key)
 
             params['replication_key_value'] = replication_key_value
         elif replication_key is not None:
-            select += ' ORDER BY `{}` ASC'.format(replication_key)
+            select_sql += ' ORDER BY `{}` ASC'.format(replication_key)
 
-        common.sync_query(cursor, catalog, state, select, params)
+        for message in common.sync_query(cursor,
+                                         catalog_entry,
+                                         state,
+                                         select_sql,
+                                         columns,
+                                         stream_version,
+                                         params):
+            yield message

--- a/tap_mysql/sync_strategies/incremental.py
+++ b/tap_mysql/sync_strategies/incremental.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=duplicate-code
 
 import pendulum
 import singer

--- a/tap_mysql/sync_strategies/incremental.py
+++ b/tap_mysql/sync_strategies/incremental.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import singer
+
+import tap_mysql.sync_strategies.common as common
+
+def sync_table(connection, catalog_entry, state):
+    columns = common.generate_column_list(catalog_entry)
+
+    if not columns:
+        LOGGER.warning(
+            'There are no columns selected for table %s, skipping it',
+            catalog_entry.table)
+        return
+
+    replication_key_value = singer.get_bookmark(state,
+                                                catalog_entry.tap_stream_id,
+                                                'replication_key_value')
+
+    replication_key = singer.get_bookmark(state,
+                                          catalog_entry.tap_stream_id,
+                                          'replication_key')
+
+    stream_version = common.get_stream_version(catalog_entry.tap_stream_id, state)
+    state = singer.write_bookmark(state,
+                                  catalog_entry.tap_stream_id,
+                                  'version',
+                                  stream_version)
+
+    # If there's a replication key, we want to emit an ACTIVATE_VERSION
+    # message at the beginning so the records show up right away. If
+    # there's no bookmark at all for this stream, assume it's the very
+    # first replication. That is, clients have never seen rows for this
+    # stream before, so they can immediately acknowledge the present
+    # version.
+    if replication_key:
+        yield singer.ActivateVersionMessage(
+            stream=catalog_entry.stream,
+            version=stream_version
+        )
+
+    with connection.cursor() as cursor:
+        select = common.generate_select(catalog_entry, columns)
+        params = {}
+
+        if replication_key_value is not None:
+            if catalog_entry.schema.properties[replication_key].format == 'date-time':
+                replication_key_value = pendulum.parse(replication_key_value)
+
+            select += ' WHERE `{}` >= %(replication_key_value)s ORDER BY `{}` ASC'.format(
+                replication_key,
+                replication_key)
+
+            params['replication_key_value'] = replication_key_value
+        elif replication_key is not None:
+            select += ' ORDER BY `{}` ASC'.format(replication_key)
+
+        common.sync_query(cursor, catalog_entry, state, select, params)


### PR DESCRIPTION
In an effort to make the tap more readable, I split split up the logic for `INCREMENTAL` and `FULL_TABLE` replication into separate files as part of the `sync_strategies` package. With this change, the branching logic is much higher up in `do_sync`. The `replication-method` metadata is now used to determine which branch to take rather than based on the existence of a replication key. There was still a lot of shared logic which has been moved into `sync_strategies.common`.