### PR TITLE
Feature/remove generator pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,7 @@ source table directly corresponds to a Singer stream.
       "key_properties": [
         "id"
       ],
-      "database_name": "example_db",
-      "is_view": false,
       "tap_stream_id": "example_db-animals",
-      "row_count": 3,
       "schema": {
         "properties": {
           "likes_getting_petted": {
@@ -151,7 +148,10 @@ source table directly corresponds to a Singer stream.
         },
         {
           "metadata": {
-            "selected-by-default": false
+            "database-name": "example_db",
+            "selected-by-default": false,
+            "is-view": false,
+            "row-count": 3
           },
           "breadcrumb": []
         },
@@ -298,10 +298,7 @@ properties file:
       "key_properties": [
         "id"
       ],
-      "database_name": "example_db",
-      "is_view": false,
       "tap_stream_id": "example_db-animals",
-      "row_count": 3,
       "schema": {
         "selected": "true",
         "properties": {

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -204,27 +204,49 @@ def discover_catalog(connection):
             schema = Schema(type='object',
                             properties={c.column_name: schema_for_column(c) for c in cols})
             md = create_column_metadata(cols)
-            entry = CatalogEntry(
-                database=table_schema,
-                table=table_name,
-                stream=table_name,
-                metadata=md,
-                tap_stream_id=table_schema + '-' + table_name,
-                schema=schema)
+            md_map = metadata.to_map(md)
+
+            md_map = metadata.write(md_map,
+                                    (),
+                                    'database-name',
+                                    table_schema)
+
+            is_view = table_info[table_schema][table_name]['is_view']
+
+            if table_schema in table_info and table_name in table_info[table_schema]:
+                row_count = table_info[table_schema][table_name].get('row_count')
+
+                if row_count is not None:
+                    md_map = metadata.write(md_map,
+                                            (),
+                                            'row-count',
+                                            row_count)
+
+                md_map = metadata.write(md_map,
+                                        (),
+                                        'is-view',
+                                        is_view)
+
             column_is_key_prop = lambda c, s: (
                 c.column_key == 'PRI' and
                 s.properties[c.column_name].inclusion != 'unsupported'
             )
+
             key_properties = [c.column_name for c in cols if column_is_key_prop(c, schema)]
 
-            is_view = table_info[table_schema][table_name]['is_view']
-
             if not is_view:
-                md.append({'metadata': {'table-key-properties' : key_properties}, 'breadcrumb': ()})
+                md_map = metadata.write(md_map,
+                                        (),
+                                        'table-key-properties',
+                                        key_properties)
 
-            if table_schema in table_info and table_name in table_info[table_schema]:
-                entry.row_count = table_info[table_schema][table_name]['row_count']
-                entry.is_view = is_view
+            entry = CatalogEntry(
+                table=table_name,
+                stream=table_name,
+                metadata=metadata.to_list(md_map),
+                tap_stream_id=table_schema + '-' + table_name,
+                schema=schema)
+
             entries.append(entry)
 
         return Catalog(entries)
@@ -281,8 +303,11 @@ def desired_columns(selected, table_schema):
 
 
 def log_engine(connection, catalog_entry):
-    if catalog_entry.is_view:
-        LOGGER.info("Beginning sync for view %s.%s", catalog_entry.database, catalog_entry.table)
+    is_view = common.get_is_view(catalog_entry)
+    database_name = common.get_database_name(catalog_entry)
+
+    if is_view:
+        LOGGER.info("Beginning sync for view %s.%s", database_name, catalog_entry.table)
     else:
         with connection.cursor() as cursor:
             cursor.execute("""
@@ -290,14 +315,14 @@ def log_engine(connection, catalog_entry):
                   FROM information_schema.tables
                  WHERE table_schema = %s
                    AND table_name   = %s
-            """, (catalog_entry.database, catalog_entry.table))
+            """, (database_name, catalog_entry.table))
 
             row = cursor.fetchone()
 
             if row:
                 LOGGER.info("Beginning sync for %s table %s.%s",
                             row[0],
-                            catalog_entry.database,
+                            database_name,
                             catalog_entry.table)
 
 
@@ -347,9 +372,11 @@ def resolve_catalog(con, catalog, state):
         replication_key = catalog_metadata.get((), {}).get('replication-key')
 
         discovered_table = discovered.get_stream(catalog_entry.tap_stream_id)
+        database_name = common.get_database_name(catalog_entry)
+
         if not discovered_table:
             LOGGER.warning('Database %s table %s was selected but does not exist',
-                           catalog_entry.database, catalog_entry.table)
+                           database_name, catalog_entry.table)
             continue
         selected = set([k for k, v in catalog_entry.schema.properties.items()
                         if v.selected or k == replication_key])
@@ -361,9 +388,7 @@ def resolve_catalog(con, catalog, state):
             tap_stream_id=catalog_entry.tap_stream_id,
             metadata=catalog_entry.metadata,
             stream=catalog_entry.stream,
-            database=catalog_entry.database,
             table=catalog_entry.table,
-            is_view=catalog_entry.is_view,
             schema=Schema(
                 type='object',
                 properties={col: discovered_table.schema.properties[col]
@@ -403,13 +428,17 @@ def do_sync(con, config, catalog, state):
         replication_method = md_map.get((), {}).get('replication-method')
         replication_key = md_map.get((), {}).get('replication-key')
 
-        if catalog_entry.is_view:
+        is_view = common.get_is_view(catalog_entry)
+
+        if is_view:
             key_properties = md_map.get((), {}).get('view-key-properties')
         else:
             key_properties = md_map.get((), {}).get('table-key-properties')
 
+        database_name = common.get_database_name(catalog_entry)
+
         with metrics.job_timer('sync_table') as timer:
-            timer.tags['database'] = catalog_entry.database
+            timer.tags['database'] = database_name
             timer.tags['table'] = catalog_entry.table
 
             log_engine(con, catalog_entry)
@@ -421,7 +450,7 @@ def do_sync(con, config, catalog, state):
 
                 incremental.sync_table(con, catalog_entry, state, columns)
             elif replication_method == 'LOG_BASED':
-                if catalog_entry.is_view:
+                if is_view:
                     raise Exception("Unable to replicate stream({}) with binlog because it is a view.".format(catalog_entry.stream))
 
                 LOGGER.info("Stream %s is using binlog replication", catalog_entry.stream)

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -219,12 +219,13 @@ def sync_table(connection, config, catalog_entry, state, columns):
                     filtered_vals = {k:v for k,v in row['values'].items()
                                     if k in columns}
 
-                    yield row_to_singer_record(catalog_entry,
-                                               stream_version,
-                                               db_column_types,
-                                               filtered_vals,
-                                               time_extracted)
+                    record_message = row_to_singer_record(catalog_entry,
+                                                          stream_version,
+                                                          db_column_types,
+                                                          filtered_vals,
+                                                          time_extracted)
 
+                    singer.write_message(record_message)
                     rows_saved = rows_saved + 1
 
 
@@ -233,11 +234,13 @@ def sync_table(connection, config, catalog_entry, state, columns):
                     filtered_vals = {k:v for k,v in row['after_values'].items()
                                     if k in columns}
 
-                    yield row_to_singer_record(catalog_entry,
-                                               stream_version,
-                                               db_column_types,
-                                               filtered_vals,
-                                               time_extracted)
+                    record_message = row_to_singer_record(catalog_entry,
+                                                          stream_version,
+                                                          db_column_types,
+                                                          filtered_vals,
+                                                          time_extracted)
+
+                    singer.write_message(record_message)
 
                     rows_saved = rows_saved + 1
             elif isinstance(binlog_event, DeleteRowsEvent):
@@ -250,11 +253,13 @@ def sync_table(connection, config, catalog_entry, state, columns):
                     filtered_vals = {k:v for k,v in vals.items()
                                     if k in columns}
 
-                    yield row_to_singer_record(catalog_entry,
-                                               stream_version,
-                                               db_column_types,
-                                               filtered_vals,
-                                               time_extracted)
+                    record_message = row_to_singer_record(catalog_entry,
+                                                          stream_version,
+                                                          db_column_types,
+                                                          filtered_vals,
+                                                          time_extracted)
+
+                    singer.write_message(record_message)
 
                     rows_saved = rows_saved + 1
 
@@ -269,6 +274,6 @@ def sync_table(connection, config, catalog_entry, state, columns):
                                       reader.log_pos)
 
             if rows_saved % UPDATE_BOOKMARK_PERIOD == 0:
-                yield singer.StateMessage(value=copy.deepcopy(state))
+                singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
-    yield singer.StateMessage(value=copy.deepcopy(state))
+    singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -186,7 +186,8 @@ def sync_table(connection, config, catalog_entry, state, columns):
         pymysql_wrapper=connection_wrapper
     )
 
-    table_path = (catalog_entry.database, catalog_entry.stream)
+    database_name = common.get_database_name(catalog_entry)
+    table_path = (database_name, catalog_entry.stream)
 
     time_extracted = utils.now()
 

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -7,6 +7,7 @@ import singer
 import time
 
 import singer.metrics as metrics
+from singer import metadata
 from singer import utils
 
 LOGGER = singer.get_logger()
@@ -27,8 +28,20 @@ def get_stream_version(tap_stream_id, state):
     return stream_version
 
 
+def get_is_view(catalog_entry):
+    md_map = metadata.to_map(catalog_entry.metadata)
+
+    return md_map.get((), {}).get('is-view')
+
+
+def get_database_name(catalog_entry):
+    md_map = metadata.to_map(catalog_entry.metadata)
+
+    return md_map.get((), {}).get('database-name')
+
 def generate_select_sql(catalog_entry, columns):
-    escaped_db = escape(catalog_entry.database)
+    database_name = get_database_name(catalog_entry)
+    escaped_db = escape(database_name)
     escaped_table = escape(catalog_entry.table)
     escaped_columns = [escape(c) for c in columns]
 
@@ -103,8 +116,9 @@ def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version
     row = cursor.fetchone()
     rows_saved = 0
 
+    database_name = get_database_name(catalog_entry)
     with metrics.record_counter(None) as counter:
-        counter.tags['database'] = catalog_entry.database
+        counter.tags['database'] = database_name
         counter.tags['table'] = catalog_entry.table
 
         while row:

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -115,7 +115,7 @@ def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version
                                                   row,
                                                   columns,
                                                   time_extracted)
-            yield record_message
+            singer.write_message(record_message)
 
             if replication_key is not None:
                 state = singer.write_bookmark(state,
@@ -128,8 +128,8 @@ def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version
                                               'replication_key_value',
                                               record_message.record[replication_key])
             if rows_saved % 1000 == 0:
-                yield singer.StateMessage(value=copy.deepcopy(state))
+                singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
             row = cursor.fetchone()
 
-    yield singer.StateMessage(value=copy.deepcopy(state))
+    singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -32,20 +32,19 @@ def sync_table(connection, catalog_entry, state, columns, stream_version):
     # For the initial replication, emit an ACTIVATE_VERSION message
     # at the beginning so the records show up right away.
     if not initial_full_table_complete and not (version_exists and state_version is None):
-        yield activate_version_message
+        singer.write_message(activate_version_message)
 
     with connection.cursor() as cursor:
         select_sql = common.generate_select_sql(catalog_entry, columns)
 
         params = {}
 
-        for message in common.sync_query(cursor,
-                                         catalog_entry,
-                                         state,
-                                         select_sql,
-                                         columns,
-                                         stream_version,
-                                         params):
-            yield message
+        common.sync_query(cursor,
+                          catalog_entry,
+                          state,
+                          select_sql,
+                          columns,
+                          stream_version,
+                          params)
 
-    yield activate_version_message
+    singer.write_message(activate_version_message)

--- a/tap_mysql/sync_strategies/incremental.py
+++ b/tap_mysql/sync_strategies/incremental.py
@@ -42,10 +42,13 @@ def sync_table(connection, catalog_entry, state, columns):
                                   'version',
                                   stream_version)
 
-    yield singer.ActivateVersionMessage(
+    activate_version_message = singer.ActivateVersionMessage(
         stream=catalog_entry.stream,
         version=stream_version
     )
+
+    singer.write_message(activate_version_message)
+
 
     with connection.cursor() as cursor:
         select_sql = common.generate_select_sql(catalog_entry, columns)
@@ -63,11 +66,10 @@ def sync_table(connection, catalog_entry, state, columns):
         elif replication_key is not None:
             select_sql += ' ORDER BY `{}` ASC'.format(replication_key)
 
-        for message in common.sync_query(cursor,
-                                         catalog_entry,
-                                         state,
-                                         select_sql,
-                                         columns,
-                                         stream_version,
-                                         params):
-            yield message
+        common.sync_query(cursor,
+                          catalog_entry,
+                          state,
+                          select_sql,
+                          columns,
+                          stream_version,
+                          params)


### PR DESCRIPTION
- Rather than yield messages, call `singer.write_message` directly when necessary
- Use `database-name`, `is-view`, and `row-count` metadata in place of `database`, `is_view`, and `row_count` catalog entry properties, respectively