### PR TITLE
Remove max and min for decimal

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -104,14 +104,7 @@ def schema_for_column(c):
 
     elif data_type == 'decimal':
         result.type = ['null', 'number']
-        result.exclusiveMaximum = True
-        result.maximum = 10 ** (c.numeric_precision - c.numeric_scale)
         result.multipleOf = 10 ** (0 - c.numeric_scale)
-        if 'unsigned' in column_type:
-            result.minimum = 0
-        else:
-            result.exclusiveMinimum = True
-            result.minimum = -10 ** (c.numeric_precision - c.numeric_scale)
         return result
 
     elif data_type in STRING_TYPES:

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -155,7 +155,9 @@ class TestTypeMapping(unittest.TestCase):
     def test_tinyint(self):
         self.assertEqual(self.schema.properties['c_tinyint'],
                          Schema(['null', 'integer'],
-                                inclusion='available'))
+                                inclusion='available',
+                                minimum=-128,
+                                maximum=127))
         self.assertEqual(self.get_metadata_for_column('c_tinyint'),
                          {'selected-by-default': True,
                           'sql-datatype': 'tinyint(4)'})
@@ -179,7 +181,9 @@ class TestTypeMapping(unittest.TestCase):
     def test_smallint(self):
         self.assertEqual(self.schema.properties['c_smallint'],
                          Schema(['null', 'integer'],
-                                inclusion='available'))
+                                inclusion='available',
+                                minimum=-32768,
+                                maximum=32767))
         self.assertEqual(self.get_metadata_for_column('c_smallint'),
                          {'selected-by-default': True,
                           'sql-datatype': 'smallint(6)'})
@@ -187,7 +191,9 @@ class TestTypeMapping(unittest.TestCase):
     def test_mediumint(self):
         self.assertEqual(self.schema.properties['c_mediumint'],
                          Schema(['null', 'integer'],
-                                inclusion='available'))
+                                inclusion='available',
+                                minimum=-8388608,
+                                maximum=8388607))
         self.assertEqual(self.get_metadata_for_column('c_mediumint'),
                          {'selected-by-default': True,
                           'sql-datatype': 'mediumint(9)'})
@@ -195,7 +201,9 @@ class TestTypeMapping(unittest.TestCase):
     def test_int(self):
         self.assertEqual(self.schema.properties['c_int'],
                          Schema(['null', 'integer'],
-                                inclusion='available'))
+                                inclusion='available',
+                                minimum=-2147483648,
+                                maximum=2147483647))
         self.assertEqual(self.get_metadata_for_column('c_int'),
                          {'selected-by-default': True,
                           'sql-datatype': 'int(11)'})
@@ -203,7 +211,9 @@ class TestTypeMapping(unittest.TestCase):
     def test_bigint(self):
         self.assertEqual(self.schema.properties['c_bigint'],
                          Schema(['null', 'integer'],
-                                inclusion='available'))
+                                inclusion='available',
+                                minimum=-9223372036854775808,
+                                maximum=9223372036854775807))
         self.assertEqual(self.get_metadata_for_column('c_bigint'),
                          {'selected-by-default': True,
                           'sql-datatype': 'bigint(20)'})
@@ -211,7 +221,10 @@ class TestTypeMapping(unittest.TestCase):
     def test_bigint_unsigned(self):
         self.assertEqual(self.schema.properties['c_bigint_unsigned'],
                          Schema(['null', 'integer'],
-                                inclusion='available'))
+                                inclusion='available',
+                                minimum=0,
+                                maximum=18446744073709551615))
+        
         self.assertEqual(self.get_metadata_for_column('c_bigint_unsigned'),
                          {'selected-by-default': True,
                           'sql-datatype': 'bigint(20) unsigned'})

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -129,10 +129,6 @@ class TestTypeMapping(unittest.TestCase):
         self.assertEqual(self.schema.properties['c_decimal'],
                          Schema(['null', 'number'],
                                 inclusion='available',
-                                maximum=10000000000,
-                                exclusiveMaximum=True,
-                                minimum=-10000000000,
-                                exclusiveMinimum=True,
                                 multipleOf=1))
         self.assertEqual(self.get_metadata_for_column('c_decimal'),
                          {'selected-by-default': True,
@@ -142,9 +138,6 @@ class TestTypeMapping(unittest.TestCase):
         self.assertEqual(self.schema.properties['c_decimal_2_unsigned'],
                          Schema(['null', 'number'],
                                 inclusion='available',
-                                maximum=1000,
-                                exclusiveMaximum=True,
-                                minimum=0,
                                 multipleOf=0.01))
         self.assertEqual(self.get_metadata_for_column('c_decimal_2_unsigned'),
                          {'selected-by-default': True,
@@ -154,10 +147,6 @@ class TestTypeMapping(unittest.TestCase):
         self.assertEqual(self.schema.properties['c_decimal_2'],
                          Schema(['null', 'number'],
                                 inclusion='available',
-                                maximum=1000000000,
-                                exclusiveMaximum=True,
-                                minimum=-1000000000,
-                                exclusiveMinimum=True,
                                 multipleOf=0.01))
         self.assertEqual(self.get_metadata_for_column('c_decimal_2'),
                          {'selected-by-default': True,

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -155,9 +155,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_tinyint(self):
         self.assertEqual(self.schema.properties['c_tinyint'],
                          Schema(['null', 'integer'],
-                                inclusion='available',
-                                minimum=-128,
-                                maximum=127))
+                                inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_tinyint'),
                          {'selected-by-default': True,
                           'sql-datatype': 'tinyint(4)'})
@@ -181,9 +179,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_smallint(self):
         self.assertEqual(self.schema.properties['c_smallint'],
                          Schema(['null', 'integer'],
-                                inclusion='available',
-                                minimum=-32768,
-                                maximum=32767))
+                                inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_smallint'),
                          {'selected-by-default': True,
                           'sql-datatype': 'smallint(6)'})
@@ -191,9 +187,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_mediumint(self):
         self.assertEqual(self.schema.properties['c_mediumint'],
                          Schema(['null', 'integer'],
-                                inclusion='available',
-                                minimum=-8388608,
-                                maximum=8388607))
+                                inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_mediumint'),
                          {'selected-by-default': True,
                           'sql-datatype': 'mediumint(9)'})
@@ -201,9 +195,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_int(self):
         self.assertEqual(self.schema.properties['c_int'],
                          Schema(['null', 'integer'],
-                                inclusion='available',
-                                minimum=-2147483648,
-                                maximum=2147483647))
+                                inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_int'),
                          {'selected-by-default': True,
                           'sql-datatype': 'int(11)'})
@@ -211,9 +203,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_bigint(self):
         self.assertEqual(self.schema.properties['c_bigint'],
                          Schema(['null', 'integer'],
-                                inclusion='available',
-                                minimum=-9223372036854775808,
-                                maximum=9223372036854775807))
+                                inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_bigint'),
                          {'selected-by-default': True,
                           'sql-datatype': 'bigint(20)'})
@@ -221,9 +211,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_bigint_unsigned(self):
         self.assertEqual(self.schema.properties['c_bigint_unsigned'],
                          Schema(['null', 'integer'],
-                                inclusion='available',
-                                minimum=0,
-                                maximum=18446744073709551615))
+                                inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_bigint_unsigned'),
                          {'selected-by-default': True,
                           'sql-datatype': 'bigint(20) unsigned'})


### PR DESCRIPTION
This is causing errors in downstream systems. If we have a DECIMAL(20, 4) field and a value of 9999999999999999.9999, downstream systems will round it up to 1E16, and it will fail validation.