### PR TITLE
Feature/auto incrementing pk support for full table

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,4 +36,4 @@ jobs:
                        --email=harrison+sandboxtest@stitchdata.com \
                        --password=$SANDBOX_PASSWORD \
                        --client-id=50 \
-                       tap_tester_mysql_binlog
+                       tap_tester.suites.mysql

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -411,8 +411,10 @@ def generate_schema_message(catalog_entry, key_properties, bookmark_properties):
         bookmark_properties=bookmark_properties
     ))
 
-def do_sync_incremental(con, config, catalog_entry, state, columns):
+def do_sync_incremental(con, catalog_entry, state, columns):
     LOGGER.info("Stream %s is using incremental replication", catalog_entry.stream)
+    key_properties = common.get_key_properties(catalog_entry)
+
     md_map = metadata.to_map(catalog_entry.metadata)
     replication_key = md_map.get((), {}).get('replication-key')
 

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -361,7 +361,11 @@ def resolve_catalog(con, catalog, state):
     # to that stream.
     currently_syncing = singer.get_currently_syncing(state)
     if currently_syncing:
-        streams = dropwhile(lambda s: s.tap_stream_id != currently_syncing, streams)
+        currently_syncing_stream = list(filter(lambda s: s.tap_stream_id == currently_syncing, streams))
+        other_streams = list(filter(lambda s: s.tap_stream_id != currently_syncing, streams))
+
+        streams = currently_syncing_stream + other_streams
+
 
     result = Catalog(streams=[])
 

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -430,12 +430,8 @@ def do_sync(con, config, catalog, state):
 
         is_view = common.get_is_view(catalog_entry)
 
-        if is_view:
-            key_properties = md_map.get((), {}).get('view-key-properties', [])
-        else:
-            key_properties = md_map.get((), {}).get('table-key-properties', [])
-
         database_name = common.get_database_name(catalog_entry)
+        key_properties = common.get_key_properties(catalog_entry)
 
         with metrics.job_timer('sync_table') as timer:
             timer.tags['database'] = database_name

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -149,7 +149,7 @@ def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version
             stream_metadata = md_map.get((), {})
             replication_method = stream_metadata.get('replication-method')
 
-            if replication_method == 'FULL_TABLE':
+            if replication_method in {'FULL_TABLE', 'LOG_BASED'}:
                 key_properties = get_key_properties(catalog_entry)
 
                 max_pk_values = singer.get_bookmark(state,

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -39,6 +39,20 @@ def get_database_name(catalog_entry):
 
     return md_map.get((), {}).get('database-name')
 
+
+def get_key_properties(catalog_entry):
+    catalog_metadata = metadata.to_map(catalog_entry.metadata)
+    stream_metadata = catalog_metadata.get((), {})
+
+    is_view = common.get_is_view(catalog_entry)
+
+    if is_view:
+        return md_map.get((), {}).get('view-key-properties', [])
+    else:
+        return md_map.get((), {}).get('table-key-properties', [])
+
+
+
 def generate_select_sql(catalog_entry, columns):
     database_name = get_database_name(catalog_entry)
     escaped_db = escape(database_name)

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -44,13 +44,12 @@ def get_key_properties(catalog_entry):
     catalog_metadata = metadata.to_map(catalog_entry.metadata)
     stream_metadata = catalog_metadata.get((), {})
 
-    is_view = common.get_is_view(catalog_entry)
+    is_view = get_is_view(catalog_entry)
 
     if is_view:
-        return md_map.get((), {}).get('view-key-properties', [])
+        return stream_metadata.get('view-key-properties', [])
     else:
-        return md_map.get((), {}).get('table-key-properties', [])
-
+        return stream_metadata.get('table-key-properties', [])
 
 
 def generate_select_sql(catalog_entry, columns):

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=too-many-arguments,duplicate-code
+# pylint: disable=too-many-arguments,duplicate-code,too-many-locals
 
 import copy
 import datetime
@@ -47,9 +47,11 @@ def get_key_properties(catalog_entry):
     is_view = get_is_view(catalog_entry)
 
     if is_view:
-        return stream_metadata.get('view-key-properties', [])
+        key_properties = stream_metadata.get('view-key-properties', [])
     else:
-        return stream_metadata.get('table-key-properties', [])
+        key_properties = stream_metadata.get('table-key-properties', [])
+
+    return key_properties
 
 
 def generate_select_sql(catalog_entry, columns):

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -78,18 +78,23 @@ def generate_pk_clause(catalog_entry, state):
                                         catalog_entry.tap_stream_id,
                                         'max_pk_values')
 
-    pk_comparisons = ["{} <= {}".format(common.escape(pk), max_pk_values[pk])
-                      for pk in key_properties]
-
     last_pk_fetched = singer.get_bookmark(state,
                                           catalog_entry.tap_stream_id,
                                           'last_pk_fetched')
 
     if last_pk_fetched:
-        last_pk_values = ""
+        pk_comparisons = ["({} > {} AND {} <= {})".format(common.escape(pk),
+                                                          last_pk_fetched[pk],
+                                                          common.escape(pk),
+                                                          max_pk_values[pk])
+                          for pk in key_properties]
     else:
-        sql = " WHERE {} ORDER BY {} ASC".format(" AND ".join(pk_comparisons),
-                                                 ", ".join(escaped_columns))
+        pk_comparisons = ["{} <= {}".format(common.escape(pk), max_pk_values[pk])
+                          for pk in key_properties]
+
+    sql = " WHERE {} ORDER BY {} ASC".format(" AND ".join(pk_comparisons),
+                                             ", ".join(escaped_columns))
+
     return sql
 
 

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -8,13 +8,12 @@ import tap_mysql.sync_strategies.common as common
 
 LOGGER = singer.get_logger()
 
-BOOKMARK_KEYS = {'version', 'initial_full_table_complete'}
+BOOKMARK_KEYS = {'last_pk_fetched', 'max_pk_values', 'version', 'initial_full_table_complete'}
 
 
-def pks_are_autoincrementing(connection, catalog_entry, key_properties):
+def pks_are_auto_incrementing(connection, catalog_entry):
     database_name = common.get_database_name(catalog_entry)
-    escaped_db = escape(database_name)
-    escaped_table = escape(catalog_entry.table)
+    key_properties = common.get_key_properties(catalog_entry)
 
     if not key_properties:
         return False
@@ -24,16 +23,14 @@ def pks_are_autoincrementing(connection, catalog_entry, key_properties):
               WHERE table_schema = '{}'
                 AND table_name = '{}'
                 AND column_name = '{}'
-                AND extra LIKE '%auto_increment%'
-"""
+
+    """
 
     with connection.cursor() as cur:
         for pk in key_properties:
-            import pdb
-            pdb.set_trace()
-            cur.execute(sql.format(escaped_db,
-                                   escaped_table,
-                                   common.escape(pk)))
+            cur.execute(sql.format(database_name,
+                                   catalog_entry.table,
+                                   pk))
 
             result = cur.fetchone()
 
@@ -41,6 +38,60 @@ def pks_are_autoincrementing(connection, catalog_entry, key_properties):
                 return False
 
     return True
+
+
+def get_max_pk_values(connection, catalog_entry):
+    database_name = common.get_database_name(catalog_entry)
+    escaped_db = common.escape(database_name)
+    escaped_table = common.escape(catalog_entry.table)
+
+    key_properties = common.get_key_properties(catalog_entry)
+    escaped_columns = [common.escape(c) for c in key_properties]
+
+    sql = """SELECT {}
+               FROM {}.{}
+              ORDER BY {}
+              LIMIT 1
+    """
+
+    select_column_clause = ", ".join(escaped_columns)
+    order_column_clause = ", ".join([pk + " DESC" for pk in escaped_columns])
+
+    with connection.cursor() as cur:
+        cur.execute(sql.format(select_column_clause,
+                               escaped_db,
+                               escaped_table,
+                               order_column_clause))
+        result = cur.fetchone()
+
+        return dict(zip(key_properties, result))
+
+
+def generate_pk_clause(catalog_entry, state):
+    key_properties = common.get_key_properties(catalog_entry)
+    escaped_columns = [common.escape(c) for c in key_properties]
+
+    where_clause = " AND ".join([pk + " > `{}`" for pk in escaped_columns])
+    order_by_clause = ", ".join(['`{}`, ' for pk in escaped_columns])
+
+    max_pk_values = singer.get_bookmark(state,
+                                        catalog_entry.tap_stream_id,
+                                        'max_pk_values')
+
+    pk_comparisons = ["{} < {}".format(common.escape(pk), max_pk_values[pk])
+                      for pk in key_properties]
+
+    last_pk_fetched = singer.get_bookmark(state,
+                                          catalog_entry.tap_stream_id,
+                                          'last_pk_fetched')
+
+    if last_pk_fetched:
+        last_pk_values = ""
+    else:
+        sql = " WHERE {} ORDER BY {} ASC".format(" AND ".join(pk_comparisons),
+                                                 ", ".join(escaped_columns))
+    return sql
+
 
 
 def sync_table(connection, catalog_entry, state, columns, stream_version):
@@ -68,7 +119,27 @@ def sync_table(connection, catalog_entry, state, columns, stream_version):
         singer.write_message(activate_version_message)
 
     with connection.cursor() as cursor:
+        key_props_are_auto_incrementing = pks_are_auto_incrementing(connection, catalog_entry)
+
         select_sql = common.generate_select_sql(catalog_entry, columns)
+
+        if key_props_are_auto_incrementing:
+            LOGGER.info("Detected auto-incrementing primary key(s) - will replicate incrementally")
+            max_pk_values = singer.get_bookmark(state,
+                                                catalog_entry.tap_stream_id,
+                                                'max_pk_values')
+
+            if not max_pk_values:
+                max_pk_values = get_max_pk_values(connection, catalog_entry)
+
+                state = singer.write_bookmark(state,
+                                              catalog_entry.tap_stream_id,
+                                              'max_pk_values',
+                                              max_pk_values)
+
+            pk_clause = generate_pk_clause(catalog_entry, state)
+
+            select_sql += pk_clause
 
         params = {}
 

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -156,4 +156,8 @@ def sync_table(connection, catalog_entry, state, columns, stream_version):
                           stream_version,
                           params)
 
+    # clear max pk value and last pk fetched upon successful sync
+    singer.clear_bookmark(state, catalog_entry.tap_stream_id, 'max_pk_values')
+    singer.clear_bookmark(state, catalog_entry.tap_stream_id, 'last_pk_fetched')
+
     singer.write_message(activate_version_message)

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -78,7 +78,7 @@ def generate_pk_clause(catalog_entry, state):
                                         catalog_entry.tap_stream_id,
                                         'max_pk_values')
 
-    pk_comparisons = ["{} < {}".format(common.escape(pk), max_pk_values[pk])
+    pk_comparisons = ["{} <= {}".format(common.escape(pk), max_pk_values[pk])
                       for pk in key_properties]
 
     last_pk_fetched = singer.get_bookmark(state,

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -151,7 +151,7 @@ def sync_table(connection, catalog_entry, state, columns, stream_version):
 
 
             if not max_pk_values:
-                LOGGER.info("Skipping table {} - no max value for auto-incrementing PK found".format(catalog_entry.table))
+                LOGGER.info("No max value for auto-incrementing PK found".format(catalog_entry.table))
             else:
                 state = singer.write_bookmark(state,
                                               catalog_entry.tap_stream_id,
@@ -162,15 +162,15 @@ def sync_table(connection, catalog_entry, state, columns, stream_version):
 
                 select_sql += pk_clause
 
-                params = {}
+        params = {}
 
-                common.sync_query(cursor,
-                                  catalog_entry,
-                                  state,
-                                  select_sql,
-                                  columns,
-                                  stream_version,
-                                  params)
+        common.sync_query(cursor,
+                          catalog_entry,
+                          state,
+                          select_sql,
+                          columns,
+                          stream_version,
+                          params)
 
     # clear max pk value and last pk fetched upon successful sync
     singer.clear_bookmark(state, catalog_entry.tap_stream_id, 'max_pk_values')

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -10,6 +10,39 @@ LOGGER = singer.get_logger()
 
 BOOKMARK_KEYS = {'version', 'initial_full_table_complete'}
 
+
+def pks_are_autoincrementing(connection, catalog_entry, key_properties):
+    database_name = common.get_database_name(catalog_entry)
+    escaped_db = escape(database_name)
+    escaped_table = escape(catalog_entry.table)
+
+    if not key_properties:
+        return False
+
+    sql = """SELECT 1
+               FROM information_schema.columns
+              WHERE table_schema = '{}'
+                AND table_name = '{}'
+                AND column_name = '{}'
+                AND extra LIKE '%auto_increment%'
+"""
+
+    with connection.cursor() as cur:
+        for pk in key_properties:
+            import pdb
+            pdb.set_trace()
+            cur.execute(sql.format(escaped_db,
+                                   escaped_table,
+                                   common.escape(pk)))
+
+            result = cur.fetchone()
+
+            if not result:
+                return False
+
+    return True
+
+
 def sync_table(connection, catalog_entry, state, columns, stream_version):
     common.whitelist_bookmark_keys(BOOKMARK_KEYS, catalog_entry.tap_stream_id, state)
 

--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -52,32 +52,177 @@ def singer_write_message_no_table_2(message):
 def singer_write_message_ok(message):
     SINGER_MESSAGES.append(message)
 
+def init_tables(conn):
+    with conn.cursor() as cur:
+        cur.execute("""
+        CREATE TABLE table_1 (
+        id  BIGINT AUTO_INCREMENT PRIMARY KEY,
+        foo BIGINT,
+        bar VARCHAR(10)
+        )""")
+
+        cur.execute("""
+        CREATE TABLE table_2 (
+        id  BIGINT AUTO_INCREMENT PRIMARY KEY,
+        foo BIGINT,
+        bar VARCHAR(10)
+        )""")
+
+        for record in TABLE_1_DATA:
+            insert_record(cur, 'table_1', record)
+
+        for record in TABLE_2_DATA:
+            insert_record(cur, 'table_2', record)
+
+    catalog = test_utils.discover_catalog(conn)
+
+    return catalog
+
+
+class BinlogInterruption(unittest.TestCase):
+    def setUp(self):
+        self.conn = test_utils.get_test_connection()
+        self.catalog = init_tables(self.conn)
+
+        for stream in self.catalog.streams:
+            stream.schema.selected = True
+            stream.key_properties = []
+            stream.schema.properties['foo'].selected = True
+            stream.schema.properties['bar'].selected = True
+            stream.stream = stream.table
+
+            if stream.table == 'table_2':
+                test_utils.set_replication_method_and_key(stream, 'LOG_BASED', None)
+            else:
+                test_utils.set_replication_method_and_key(stream, 'FULL_TABLE', None)
+
+        global TABLE_2_RECORD_COUNT
+        TABLE_2_RECORD_COUNT = 0
+
+        global SINGER_MESSAGES
+        SINGER_MESSAGES.clear()
+
+    def tearDown(self):
+        if self.conn:
+            self.conn.close()
+
+    def test_table_2_interrupted(self):
+        singer.write_message = singer_write_message_no_table_2
+
+        state = {}
+        failed_syncing_table_2 = False
+
+        try:
+            tap_mysql.do_sync(self.conn, test_utils.get_db_config(), self.catalog, state)
+        except Exception as ex:
+            if str(ex) == 'simulated exception':
+                failed_syncing_table_2 = True
+
+        self.assertTrue(failed_syncing_table_2)
+
+        record_messages_1 = [[m.stream, m.record] for m in SINGER_MESSAGES if type(m) == singer.RecordMessage]
+        self.assertEqual(record_messages_1,
+                         [['table_1', {'id': 1, 'bar': 'abc', 'foo': 100}],
+                          ['table_1', {'id': 2, 'bar': 'def', 'foo': 200}],
+                          ['table_1', {'id': 3, 'bar': 'ghi', 'foo': 300}],
+                          ['table_2', {'id': 1, 'bar': 'ghi', 'foo': 300}]])
+
+        self.assertEqual(state['currently_syncing'], 'tap_mysql_test-table_2')
+
+        table_1_bookmark = state['bookmarks']['tap_mysql_test-table_1']
+        table_2_bookmark = state['bookmarks']['tap_mysql_test-table_2']
+
+        self.assertEqual(table_1_bookmark,
+                         {'initial_full_table_complete': True})
+
+        self.assertIsNone(table_2_bookmark.get('initial_full_table_complete'))
+
+        table_2_version = table_2_bookmark['version']
+        self.assertIsNotNone(table_2_version)
+
+        self.assertEqual(table_2_bookmark['max_pk_values'], {'id': 3})
+        self.assertEqual(table_2_bookmark['last_pk_fetched'], {'id': 1})
+
+        self.assertIsNotNone(table_2_bookmark.get('log_file'))
+        self.assertIsNotNone(table_2_bookmark.get('log_pos'))
+
+        failed_syncing_table_2 = False
+        singer.write_message = singer_write_message_ok
+
+        table_2_RECORD_COUNT = 0
+        SINGER_MESSAGES.clear()
+
+        tap_mysql.do_sync(self.conn, test_utils.get_db_config(), self.catalog, state)
+
+        self.assertFalse(failed_syncing_table_2)
+
+        record_messages_2 = [[m.stream, m.record] for m in SINGER_MESSAGES if type(m) == singer.RecordMessage]
+        self.assertEqual(record_messages_2,
+                         [['table_2', {'id': 2, 'bar': 'def', 'foo': 200}],
+                          ['table_2', {'id': 3, 'bar': 'abc', 'foo': 100}],
+                          ['table_1', {'id': 1, 'bar': 'abc', 'foo': 100}],
+                          ['table_1', {'id': 2, 'bar': 'def', 'foo': 200}],
+                          ['table_1', {'id': 3, 'bar': 'ghi', 'foo': 300}]])
+
+        self.assertIsNone(state['currently_syncing'])
+
+        table_1_bookmark = state['bookmarks']['tap_mysql_test-table_1']
+        table_2_bookmark = state['bookmarks']['tap_mysql_test-table_2']
+
+        self.assertEqual(table_1_bookmark,
+                         {'initial_full_table_complete': True})
+
+        self.assertIsNone(table_2_bookmark.get('initial_full_table_complete'))
+
+        table_2_version = table_2_bookmark['version']
+        self.assertIsNotNone(table_2_version)
+
+        self.assertIsNone(table_2_bookmark.get('max_pk_values'))
+        self.assertIsNone(table_2_bookmark.get('last_pk_fetched'))
+
+        self.assertIsNotNone(table_2_bookmark.get('log_file'))
+        self.assertIsNotNone(table_2_bookmark.get('log_pos'))
+
+
+        new_table_2_records = [[ 400, 'jkl' ],
+                               [ 500, 'mno' ]]
+
+        with self.conn.cursor() as cur:
+            for record in new_table_2_records:
+                insert_record(cur, 'table_2', record)
+
+        TABLE_2_RECORD_COUNT = 0
+        SINGER_MESSAGES.clear()
+
+        tap_mysql.do_sync(self.conn, test_utils.get_db_config(), self.catalog, state)
+
+        self.assertFalse(failed_syncing_table_2)
+
+        record_messages_3 = [[m.stream, m.record] for m in SINGER_MESSAGES if type(m) == singer.RecordMessage]
+        self.assertEqual(record_messages_3,
+                         [['table_1', {'id': 1, 'bar': 'abc', 'foo': 100}],
+                          ['table_1', {'id': 2, 'bar': 'def', 'foo': 200}],
+                          ['table_1', {'id': 3, 'bar': 'ghi', 'foo': 300}],
+                          ['table_2', {'id': 4, 'bar': 'jkl', 'foo': 400}],
+                          ['table_2', {'id': 5, 'bar': 'mno', 'foo': 500}]])
+
+        self.assertIsNone(state['currently_syncing'])
+
+        table_1_bookmark = state['bookmarks']['tap_mysql_test-table_1']
+        table_2_bookmark = state['bookmarks']['tap_mysql_test-table_2']
+
+        self.assertEqual(table_1_bookmark,
+                         {'initial_full_table_complete': True})
+
+        self.assertIsNone(table_2_bookmark.get('initial_full_table_complete'))
+        self.assertIsNotNone(table_2_bookmark.get('log_file'))
+        self.assertIsNotNone(table_2_bookmark.get('log_pos'))
+
 
 class FullTableInterruption(unittest.TestCase):
     def setUp(self):
         self.conn = test_utils.get_test_connection()
-        with self.conn.cursor() as cur:
-            cur.execute("""
-            CREATE TABLE table_1 (
-            id  BIGINT AUTO_INCREMENT PRIMARY KEY,
-            foo BIGINT,
-            bar VARCHAR(10)
-            )""")
-
-            cur.execute("""
-            CREATE TABLE table_2 (
-            id  BIGINT AUTO_INCREMENT PRIMARY KEY,
-            foo BIGINT,
-            bar VARCHAR(10)
-            )""")
-
-            for record in TABLE_1_DATA:
-                insert_record(cur, 'table_1', record)
-
-            for record in TABLE_2_DATA:
-                insert_record(cur, 'table_2', record)
-
-            self.catalog = test_utils.discover_catalog(self.conn)
+        self.catalog = init_tables(self.conn)
 
         for stream in self.catalog.streams:
             stream.schema.selected = True
@@ -87,10 +232,7 @@ class FullTableInterruption(unittest.TestCase):
             stream.stream = stream.table
             test_utils.set_replication_method_and_key(stream, 'FULL_TABLE', None)
 
-        global COW_RECORD_COUNT
         TABLE_2_RECORD_COUNT = 0
-
-        global SINGER_MESSAGES
         SINGER_MESSAGES.clear()
 
     def tearDown(self):
@@ -110,7 +252,6 @@ class FullTableInterruption(unittest.TestCase):
                 failed_syncing_table_2 = True
 
         self.assertTrue(failed_syncing_table_2)
-
 
         record_messages_1 = [[m.stream, m.record] for m in SINGER_MESSAGES if type(m) == singer.RecordMessage]
         self.assertEqual(record_messages_1,
@@ -132,15 +273,10 @@ class FullTableInterruption(unittest.TestCase):
             }
         }
 
-        self.assertEqual(state, expected_state_1)
-
         failed_syncing_table_2 = False
         singer.write_message = singer_write_message_ok
 
-        global COW_RECORD_COUNT
         TABLE_2_RECORD_COUNT = 0
-
-        global SINGER_MESSAGES
         SINGER_MESSAGES.clear()
 
         tap_mysql.do_sync(self.conn, {}, self.catalog, state)
@@ -158,10 +294,10 @@ class FullTableInterruption(unittest.TestCase):
         expected_state_2 = {
             'currently_syncing': None,
             'bookmarks': {
-                'tap_mysql_test-table_2': {
+                'tap_mysql_test-table_1': {
                     'initial_full_table_complete': True
                 },
-                'tap_mysql_test-table_1': {
+                'tap_mysql_test-table_2': {
                     'initial_full_table_complete': True
                 }
             }
@@ -171,6 +307,6 @@ class FullTableInterruption(unittest.TestCase):
 
 
 if __name__== "__main__":
-    test1 = FullTableInterruption()
+    test1 = BinlogInterruption()
     test1.setUp()
     test1.test_table_2_interrupted()

--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -120,7 +120,9 @@ class BinlogInterruption(unittest.TestCase):
 
         self.assertTrue(failed_syncing_table_2)
 
-        record_messages_1 = [[m.stream, m.record] for m in SINGER_MESSAGES if type(m) == singer.RecordMessage]
+        record_messages_1 = [[m.stream, m.record] for m in SINGER_MESSAGES
+                             if isinstance(m, singer.RecordMessage)]
+
         self.assertEqual(record_messages_1,
                          [['table_1', {'id': 1, 'bar': 'abc', 'foo': 100}],
                           ['table_1', {'id': 2, 'bar': 'def', 'foo': 200}],
@@ -156,7 +158,9 @@ class BinlogInterruption(unittest.TestCase):
 
         self.assertFalse(failed_syncing_table_2)
 
-        record_messages_2 = [[m.stream, m.record] for m in SINGER_MESSAGES if type(m) == singer.RecordMessage]
+        record_messages_2 = [[m.stream, m.record] for m in SINGER_MESSAGES
+                             if isinstance(m, singer.RecordMessage)]
+
         self.assertEqual(record_messages_2,
                          [['table_2', {'id': 2, 'bar': 'def', 'foo': 200}],
                           ['table_2', {'id': 3, 'bar': 'abc', 'foo': 100}],
@@ -198,7 +202,9 @@ class BinlogInterruption(unittest.TestCase):
 
         self.assertFalse(failed_syncing_table_2)
 
-        record_messages_3 = [[m.stream, m.record] for m in SINGER_MESSAGES if type(m) == singer.RecordMessage]
+        record_messages_3 = [[m.stream, m.record] for m in SINGER_MESSAGES
+                             if isinstance(m, singer.RecordMessage)]
+
         self.assertEqual(record_messages_3,
                          [['table_1', {'id': 1, 'bar': 'abc', 'foo': 100}],
                           ['table_1', {'id': 2, 'bar': 'def', 'foo': 200}],
@@ -232,7 +238,10 @@ class FullTableInterruption(unittest.TestCase):
             stream.stream = stream.table
             test_utils.set_replication_method_and_key(stream, 'FULL_TABLE', None)
 
+        global TABLE_2_RECORD_COUNT
         TABLE_2_RECORD_COUNT = 0
+
+        global SINGER_MESSAGES
         SINGER_MESSAGES.clear()
 
     def tearDown(self):
@@ -253,12 +262,15 @@ class FullTableInterruption(unittest.TestCase):
 
         self.assertTrue(failed_syncing_table_2)
 
-        record_messages_1 = [[m.stream, m.record] for m in SINGER_MESSAGES if type(m) == singer.RecordMessage]
+        record_messages_1 = [[m.stream, m.record] for m in SINGER_MESSAGES
+                             if isinstance(m, singer.RecordMessage)]
+
         self.assertEqual(record_messages_1,
                          [['table_1', {'id': 1, 'bar': 'abc', 'foo': 100}],
                           ['table_1', {'id': 2, 'bar': 'def', 'foo': 200}],
                           ['table_1', {'id': 3, 'bar': 'ghi', 'foo': 300}],
-                          ['table_2', {'id': 1, 'bar': 'ghi', 'foo': 300}]])
+                          ['table_2', {'id': 1, 'bar': 'ghi', 'foo': 300}]
+                         ])
 
         expected_state_1 = {
             'currently_syncing': 'tap_mysql_test-table_2',
@@ -283,7 +295,7 @@ class FullTableInterruption(unittest.TestCase):
 
         self.assertFalse(failed_syncing_table_2)
 
-        record_messages_2 = [[m.stream, m.record] for m in SINGER_MESSAGES if type(m) == singer.RecordMessage]
+        record_messages_2 = [[m.stream, m.record] for m in SINGER_MESSAGES if isinstance(m, singer.RecordMessage)]
         self.assertEqual(record_messages_2,
                          [['table_2', {'id': 2, 'bar': 'def', 'foo': 200}],
                           ['table_2', {'id': 3, 'bar': 'abc', 'foo': 100}],

--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -1,0 +1,176 @@
+import copy
+import os
+import pymysql
+import unittest
+import singer
+import singer.metadata
+import tap_mysql
+
+try:
+    import tests.utils as test_utils
+except ImportError:
+    import utils as test_utils
+
+LOGGER = singer.get_logger()
+
+SINGER_MESSAGES = []
+TABLE_2_RECORD_COUNT = 0
+
+#                FOO   BAR
+TABLE_1_DATA = [[ 100, 'abc' ],
+                [ 200, 'def' ],
+                [ 300, 'ghi' ]]
+
+TABLE_2_DATA = TABLE_1_DATA[::-1]
+
+def insert_record(cursor, table_name, record):
+    value_sql = ",".join(["%s" for i in range(len(record))])
+
+    insert_sql = """
+        INSERT INTO {}.{}
+               ( `foo`, `bar` )
+        VALUES ( {} )""".format(
+            test_utils.DB_NAME,
+            table_name,
+            value_sql)
+
+    cursor.execute(insert_sql, record)
+
+
+def singer_write_message_no_table_2(message):
+    global TABLE_2_RECORD_COUNT
+
+    if isinstance(message, singer.RecordMessage) and message.stream == 'table_2':
+        TABLE_2_RECORD_COUNT = TABLE_2_RECORD_COUNT + 1
+
+        if TABLE_2_RECORD_COUNT > 1:
+            raise Exception("simulated exception")
+
+    SINGER_MESSAGES.append(message)
+
+
+def singer_write_message_ok(message):
+    SINGER_MESSAGES.append(message)
+
+
+class FullTableInterruption(unittest.TestCase):
+    def setUp(self):
+        self.conn = test_utils.get_test_connection()
+        with self.conn.cursor() as cur:
+            cur.execute("""
+            CREATE TABLE table_1 (
+            id  BIGINT AUTO_INCREMENT PRIMARY KEY,
+            foo BIGINT,
+            bar VARCHAR(10)
+            )""")
+
+            cur.execute("""
+            CREATE TABLE table_2 (
+            id  BIGINT AUTO_INCREMENT PRIMARY KEY,
+            foo BIGINT,
+            bar VARCHAR(10)
+            )""")
+
+            for record in TABLE_1_DATA:
+                insert_record(cur, 'table_1', record)
+
+            for record in TABLE_2_DATA:
+                insert_record(cur, 'table_2', record)
+
+            self.catalog = test_utils.discover_catalog(self.conn)
+
+        for stream in self.catalog.streams:
+            stream.schema.selected = True
+            stream.key_properties = []
+            stream.schema.properties['foo'].selected = True
+            stream.schema.properties['bar'].selected = True
+            stream.stream = stream.table
+            test_utils.set_replication_method_and_key(stream, 'FULL_TABLE', None)
+
+        global COW_RECORD_COUNT
+        TABLE_2_RECORD_COUNT = 0
+
+        global SINGER_MESSAGES
+        SINGER_MESSAGES.clear()
+
+    def tearDown(self):
+        if self.conn:
+            self.conn.close()
+
+    def test_table_2_interrupted(self):
+        singer.write_message = singer_write_message_no_table_2
+
+        state = {}
+        failed_syncing_table_2 = False
+
+        try:
+            tap_mysql.do_sync(self.conn, {}, self.catalog, state)
+        except Exception as ex:
+            if str(ex) == 'simulated exception':
+                failed_syncing_table_2 = True
+
+        self.assertTrue(failed_syncing_table_2)
+
+
+        record_messages_1 = [[m.stream, m.record] for m in SINGER_MESSAGES if type(m) == singer.RecordMessage]
+        self.assertEqual(record_messages_1,
+                         [['table_1', {'id': 1, 'bar': 'abc', 'foo': 100}],
+                          ['table_1', {'id': 2, 'bar': 'def', 'foo': 200}],
+                          ['table_1', {'id': 3, 'bar': 'ghi', 'foo': 300}],
+                          ['table_2', {'id': 1, 'bar': 'ghi', 'foo': 300}]])
+
+        expected_state_1 = {
+            'currently_syncing': 'tap_mysql_test-table_2',
+            'bookmarks': {
+                'tap_mysql_test-table_2': {
+                    'last_pk_fetched': {'id': 1},
+                    'max_pk_values': {'id': 3}
+                },
+                'tap_mysql_test-table_1': {
+                    'initial_full_table_complete': True
+                }
+            }
+        }
+
+        self.assertEqual(state, expected_state_1)
+
+        failed_syncing_table_2 = False
+        singer.write_message = singer_write_message_ok
+
+        global COW_RECORD_COUNT
+        TABLE_2_RECORD_COUNT = 0
+
+        global SINGER_MESSAGES
+        SINGER_MESSAGES.clear()
+
+        tap_mysql.do_sync(self.conn, {}, self.catalog, state)
+
+        self.assertFalse(failed_syncing_table_2)
+
+        record_messages_2 = [[m.stream, m.record] for m in SINGER_MESSAGES if type(m) == singer.RecordMessage]
+        self.assertEqual(record_messages_2,
+                         [['table_2', {'id': 2, 'bar': 'def', 'foo': 200}],
+                          ['table_2', {'id': 3, 'bar': 'abc', 'foo': 100}],
+                          ['table_1', {'id': 1, 'bar': 'abc', 'foo': 100}],
+                          ['table_1', {'id': 2, 'bar': 'def', 'foo': 200}],
+                          ['table_1', {'id': 3, 'bar': 'ghi', 'foo': 300}]])
+
+        expected_state_2 = {
+            'currently_syncing': None,
+            'bookmarks': {
+                'tap_mysql_test-table_2': {
+                    'initial_full_table_complete': True
+                },
+                'tap_mysql_test-table_1': {
+                    'initial_full_table_complete': True
+                }
+            }
+        }
+
+        self.assertEqual(state, expected_state_2)
+
+
+if __name__== "__main__":
+    test1 = FullTableInterruption()
+    test1.setUp()
+    test1.test_table_2_interrupted()

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -327,7 +327,7 @@ class TestCurrentStream(unittest.TestCase):
 
         SINGER_MESSAGES.clear()
         tap_mysql.do_sync(self.con, {}, self.catalog, state)
-        self.assertRegexpMatches(currently_syncing_seq(SINGER_MESSAGES), '^b+_+')
+        self.assertRegexpMatches(currently_syncing_seq(SINGER_MESSAGES), '^b+a+_+')
 
 def message_types_and_versions(messages):
     message_types = []

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,68 @@
+import os
+import pymysql
+import singer
+import tap_mysql
+import tap_mysql.sync_strategies.common as common
+
+DB_NAME='tap_mysql_test'
+
+def get_db_config():
+    config = {}
+    config['host'] = os.environ.get('TAP_MYSQL_HOST')
+    config['port'] = int(os.environ.get('TAP_MYSQL_PORT'))
+    config['user'] = os.environ.get('TAP_MYSQL_USER')
+    config['password'] = os.environ.get('TAP_MYSQL_PASSWORD')
+    config['charset'] = 'utf8'
+    if not config['password']:
+        del config['password']
+
+    return config
+
+
+def get_test_connection():
+    db_config = get_db_config()
+
+    con = pymysql.connect(**db_config)
+
+    try:
+        with con.cursor() as cur:
+            try:
+                cur.execute('DROP DATABASE {}'.format(DB_NAME))
+            except:
+                pass
+            cur.execute('CREATE DATABASE {}'.format(DB_NAME))
+    finally:
+        con.close()
+
+    db_config['database'] = DB_NAME
+    db_config['autocommit'] = True
+
+    return pymysql.connect(**db_config)
+
+
+def discover_catalog(connection):
+    catalog = tap_mysql.discover_catalog(connection)
+    streams = []
+
+    for stream in catalog.streams:
+        database_name = common.get_database_name(stream)
+
+        if database_name == DB_NAME:
+            streams.append(stream)
+
+    catalog.streams = streams
+
+    return catalog
+
+
+def set_replication_method_and_key(stream, r_method, r_key):
+    new_md = singer.metadata.to_map(stream.metadata)
+    old_md = new_md.get(())
+    if r_method:
+        old_md.update({'replication-method': r_method})
+
+    if r_key:
+        old_md.update({'replication-key': r_key})
+
+    stream.metadata = singer.metadata.to_list(new_md)
+    return stream


### PR DESCRIPTION
Currently, full table is treated as an atomic sync. If interrupted, the sync must begin from the beginning. A table that has an auto-incrementing primary key can be synced in an incremental fashion allowing it to span multiple jobs.

This PR introduces two new state fields to `FULL_TABLE` replication. Before performing a `FULL_TABLE` sync, the tap determines whether or not it can be run incrementally by discovering if the primary key(s) are auto incrementing. If they are, the tap then finds the max values and stores them in `max_pk_values`. A `FULL_TABLE` query will use this as its upper bound. As the tap fetches rows, it will update `last_pk_fetched` which is used in case the sync needs to be resumed later. When `last_pk_fetched` exists in the state, it used as the lower bound.