### PR TITLE
Feature/prioritize streams without state

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -142,8 +142,11 @@ def create_column_metadata(cols):
 def discover_catalog(connection, config):
     '''Returns a Catalog describing the structure of the database.'''
 
+
+    filter_dbs = config.get('filter_dbs')
+
     with connection.cursor() as cursor:
-        if config.get('filter_dbs'):
+        if filter_dbs:
             table_schema_clause = "WHERE table_schema IN ({})".format(filter_dbs)
         else:
             table_schema_clause = """

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -139,11 +139,11 @@ def create_column_metadata(cols):
     return metadata.to_list(mdata)
 
 
-def discover_catalog(connection, filter_dbs=None):
+def discover_catalog(connection, config):
     '''Returns a Catalog describing the structure of the database.'''
 
     with connection.cursor() as cursor:
-        if filter_dbs:
+        if config.get('filter_dbs'):
             table_schema_clause = "WHERE table_schema IN ({})".format(filter_dbs)
         else:
             table_schema_clause = """
@@ -253,8 +253,8 @@ def discover_catalog(connection, filter_dbs=None):
         return Catalog(entries)
 
 
-def do_discover(connection, filter_dbs):
-    discover_catalog(connection, filter_dbs).dump()
+def do_discover(connection, config):
+    discover_catalog(connection, config).dump()
 
 
 # TODO: Maybe put in a singer-db-utils library.
@@ -648,7 +648,7 @@ def main_impl():
 
     log_server_params(connection)
     if args.discover:
-        do_discover(connection, args.filter_dbs)
+        do_discover(connection, args.config)
     elif args.catalog:
         state = args.state or {}
         do_sync(connection, args.config, args.catalog, state)

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -143,14 +143,15 @@ def discover_catalog(connection, filter_dbs=None):
     '''Returns a Catalog describing the structure of the database.'''
 
     with connection.cursor() as cursor:
-        table_schema_filter = """
-        'information_schema',
-        'performance_schema',
-        'mysql'
-        """
-
         if filter_dbs:
-            table_schema_filter + "," + filter_dbs
+            table_schema_clause = "WHERE table_schema IN ({})".format(filter_dbs)
+        else:
+            table_schema_clause = """
+            WHERE table_schema NOT IN (
+            'information_schema',
+            'performance_schema',
+            'mysql'
+            )"""
 
         cursor.execute("""
             SELECT table_schema,
@@ -158,8 +159,8 @@ def discover_catalog(connection, filter_dbs=None):
                    table_type,
                    table_rows
                 FROM information_schema.tables
-                WHERE table_schema NOT IN ({})
-        """.format(table_schema_filter))
+                {}
+        """.format(table_schema_clause))
 
         table_info = {}
 

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -336,7 +336,7 @@ def is_selected(stream):
     return table_md.get('selected') or stream.is_selected()
 
 
-def resolve_catalog(con, catalog, state):
+def resolve_catalog(con, catalog, config, state):
     '''Returns the Catalog of data we're going to sync.
 
     Takes the Catalog we read from the input file and turns it into a
@@ -356,7 +356,7 @@ def resolve_catalog(con, catalog, state):
         columns used as replication keys.
 
     '''
-    discovered = discover_catalog(con)
+    discovered = discover_catalog(con, config)
 
     # Filter catalog to include only selected streams
     streams_with_state = []
@@ -556,7 +556,7 @@ def do_sync_full_table(con, catalog_entry, state, columns):
 
 
 def do_sync(con, config, catalog, state):
-    catalog = resolve_catalog(con, catalog, state)
+    catalog = resolve_catalog(con, catalog, config, state)
 
     for catalog_entry in catalog.streams:
         columns = list(catalog_entry.schema.properties.keys())

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -253,8 +253,8 @@ def discover_catalog(connection, filter_dbs=None):
         return Catalog(entries)
 
 
-def do_discover(connection):
-    discover_catalog(connection).dump()
+def do_discover(connection, filter_dbs):
+    discover_catalog(connection, filter_dbs).dump()
 
 
 # TODO: Maybe put in a singer-db-utils library.

--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -74,7 +74,7 @@ def init_tables(conn):
         for record in TABLE_2_DATA:
             insert_record(cur, 'table_2', record)
 
-    catalog = test_utils.discover_catalog(conn)
+    catalog = test_utils.discover_catalog(conn, {})
 
     return catalog
 

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -62,7 +62,7 @@ class TestTypeMapping(unittest.TestCase):
             c_year YEAR
             )''')
 
-            catalog = test_utils.discover_catalog(con)
+            catalog = test_utils.discover_catalog(con, {})
             cls.schema = catalog.streams[0].schema
             cls.metadata = catalog.streams[0].metadata
 
@@ -257,7 +257,7 @@ class TestSchemaMessages(unittest.TestCase):
                       b INTEGER)
                 ''')
 
-            catalog = test_utils.discover_catalog(con)
+            catalog = test_utils.discover_catalog(con, {})
             catalog.streams[0].stream = 'tab'
             catalog.streams[0].schema.selected = True
             catalog.streams[0].schema.properties['a'].selected = True
@@ -294,7 +294,7 @@ class TestCurrentStream(unittest.TestCase):
             cursor.execute('INSERT INTO b (val) VALUES (1)')
             cursor.execute('INSERT INTO c (val) VALUES (1)')
 
-        self.catalog = test_utils.discover_catalog(self.con)
+        self.catalog = test_utils.discover_catalog(self.con, {})
 
         for stream in self.catalog.streams:
             stream.schema.selected = True
@@ -348,7 +348,7 @@ class TestStreamVersionFullTable(unittest.TestCase):
             cursor.execute('CREATE TABLE full_table (val int)')
             cursor.execute('INSERT INTO full_table (val) VALUES (1)')
 
-        self.catalog = test_utils.discover_catalog(self.con)
+        self.catalog = test_utils.discover_catalog(self.con, {})
         for stream in self.catalog.streams:
             stream.schema.selected = True
             stream.key_properties = []
@@ -451,7 +451,7 @@ class TestIncrementalReplication(unittest.TestCase):
             cursor.execute('INSERT INTO integer_incremental (val, updated) VALUES (2, 2)')
             cursor.execute('INSERT INTO integer_incremental (val, updated) VALUES (3, 3)')
 
-        self.catalog = test_utils.discover_catalog(self.con)
+        self.catalog = test_utils.discover_catalog(self.con, {})
 
         for stream in self.catalog.streams:
             stream.schema.selected = True
@@ -573,7 +573,7 @@ class TestBinlogReplication(unittest.TestCase):
 
         self.con.commit()
 
-        self.catalog = test_utils.discover_catalog(self.con)
+        self.catalog = test_utils.discover_catalog(self.con, {})
 
         for stream in self.catalog.streams:
             stream.schema.selected = True
@@ -741,7 +741,7 @@ class TestViews(unittest.TestCase):
             self.con.close()
 
     def test_discovery_sets_is_view(self):
-        catalog = test_utils.discover_catalog(self.con)
+        catalog = test_utils.discover_catalog(self.con, {})
         is_view = {}
 
         for stream in catalog.streams:
@@ -754,7 +754,7 @@ class TestViews(unittest.TestCase):
              'a_view': True})
 
     def test_do_not_discover_key_properties_for_view(self):
-        catalog = test_utils.discover_catalog(self.con)
+        catalog = test_utils.discover_catalog(self.con, {})
         primary_keys = {}
         for c in catalog.streams:
             primary_keys[c.table] = singer.metadata.to_map(c.metadata).get((), {}).get('table-key-properties')
@@ -772,7 +772,7 @@ class TestEscaping(unittest.TestCase):
             cursor.execute('CREATE TABLE a (`b c` int)')
             cursor.execute('INSERT INTO a (`b c`) VALUES (1)')
 
-        self.catalog = test_utils.discover_catalog(self.con)
+        self.catalog = test_utils.discover_catalog(self.con. {})
 
         self.catalog.streams[0].stream = 'some_stream_name'
         self.catalog.streams[0].schema.selected = True
@@ -809,7 +809,7 @@ class TestUnsupportedPK(unittest.TestCase):
             self.con.close()
 
     def runTest(self):
-        catalog = test_utils.discover_catalog(self.con)
+        catalog = test_utils.discover_catalog(self.con, {})
 
         primary_keys = {}
         for c in catalog.streams:

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -772,7 +772,7 @@ class TestEscaping(unittest.TestCase):
             cursor.execute('CREATE TABLE a (`b c` int)')
             cursor.execute('INSERT INTO a (`b c`) VALUES (1)')
 
-        self.catalog = test_utils.discover_catalog(self.con. {})
+        self.catalog = test_utils.discover_catalog(self.con, {})
 
         self.catalog.streams[0].stream = 'some_stream_name'
         self.catalog.streams[0].schema.selected = True

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -40,8 +40,8 @@ def get_test_connection():
     return pymysql.connect(**db_config)
 
 
-def discover_catalog(connection):
-    catalog = tap_mysql.discover_catalog(connection)
+def discover_catalog(connection, catalog):
+    catalog = tap_mysql.discover_catalog(connection, catalog)
     streams = []
 
     for stream in catalog.streams:


### PR DESCRIPTION
Currently, we only prioritize the stream marked as `currently_syncing` within the state. This will result in possibly replicating tables that have been replicated in the past prior to those that have never been replicated. The priority will now be the stream marked as `currently_syncing`, then streams which have never been synced (filtered based on lack of `bookmarks` entry in the state`, then streams which have been synced in the past.

An unrelated change is that now discovery can be limited based on a provided list.