### PR TITLE
Fix/open connections as needed

### DIFF
--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -23,6 +23,8 @@ match_hostname = ssl.match_hostname
 def connect_with_backoff(connection):
     connection.connect()
 
+    return connection
+
 
 def parse_internal_hostname(hostname):
     # special handling for google cloud

--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -23,6 +23,31 @@ match_hostname = ssl.match_hostname
 def connect_with_backoff(connection):
     connection.connect()
 
+    warnings = []
+    with connection.cursor() as cur:
+        try:
+            cur.execute('SET @@session.time_zone="+0:00"')
+        except pymysql.err.InternalError as e:
+            warnings.append('Could not set session.time_zone. Error: ({}) {}'.format(*e.args))
+
+        try:
+            cur.execute('SET @@session.wait_timeout=2700')
+        except pymysql.err.InternalError as e:
+             warnings.append('Could not set session.wait_timeout. Error: ({}) {}'.format(*e.args))
+
+        try:
+            cur.execute('SET @@session.innodb_lock_wait_timeout=2700')
+        except pymysql.err.InternalError as e:
+            warnings.append(
+                'Could not set session.innodb_lock_wait_timeout. Error: ({}) {}'.format(*e.args)
+                )
+
+        if warnings:
+            LOGGER.info(("Encountered non-fatal errors when configuring MySQL session that could "
+                         "impact performance:"))
+        for w in warnings:
+            LOGGER.warning(w)
+
     return connection
 
 

--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -137,6 +137,15 @@ class MySQLConnection(pymysql.connections.Connection):
             self.client_flag |= CLIENT.SSL
 
 
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, *exc_info):
+        del exc_info
+        self.close()
+
+
 def make_connection_wrapper(config):
     class ConnectionWrapper(MySQLConnection):
         def __init__(self, *args, **kwargs):

--- a/tap_mysql/sync_strategies/incremental.py
+++ b/tap_mysql/sync_strategies/incremental.py
@@ -5,13 +5,14 @@ import pendulum
 import singer
 from singer import metadata
 
+from tap_mysql.connection import connect_with_backoff, MySQLConnection
 import tap_mysql.sync_strategies.common as common
 
 LOGGER = singer.get_logger()
 
 BOOKMARK_KEYS = {'replication_key', 'replication_key_value', 'version'}
 
-def sync_table(connection, catalog_entry, state, columns):
+def sync_table(mysql_conn, catalog_entry, state, columns):
     common.whitelist_bookmark_keys(BOOKMARK_KEYS, catalog_entry.tap_stream_id, state)
 
     catalog_metadata = metadata.to_map(catalog_entry.metadata)
@@ -48,27 +49,27 @@ def sync_table(connection, catalog_entry, state, columns):
 
     singer.write_message(activate_version_message)
 
+    with connect_with_backoff(mysql_conn) as open_conn:
+        with open_conn.cursor() as cur:
+            select_sql = common.generate_select_sql(catalog_entry, columns)
+            params = {}
 
-    with connection.cursor() as cursor:
-        select_sql = common.generate_select_sql(catalog_entry, columns)
-        params = {}
+            if replication_key_value is not None:
+                if catalog_entry.schema.properties[replication_key_metadata].format == 'date-time':
+                    replication_key_value = pendulum.parse(replication_key_value)
 
-        if replication_key_value is not None:
-            if catalog_entry.schema.properties[replication_key_metadata].format == 'date-time':
-                replication_key_value = pendulum.parse(replication_key_value)
+                select_sql += ' WHERE `{}` >= %(replication_key_value)s ORDER BY `{}` ASC'.format(
+                    replication_key_metadata,
+                    replication_key_metadata)
 
-            select_sql += ' WHERE `{}` >= %(replication_key_value)s ORDER BY `{}` ASC'.format(
-                replication_key_metadata,
-                replication_key_metadata)
+                params['replication_key_value'] = replication_key_value
+            elif replication_key_metadata is not None:
+                select_sql += ' ORDER BY `{}` ASC'.format(replication_key_metadata)
 
-            params['replication_key_value'] = replication_key_value
-        elif replication_key_metadata is not None:
-            select_sql += ' ORDER BY `{}` ASC'.format(replication_key_metadata)
-
-        common.sync_query(cursor,
-                          catalog_entry,
-                          state,
-                          select_sql,
-                          columns,
-                          stream_version,
-                          params)
+            common.sync_query(cur,
+                              catalog_entry,
+                              state,
+                              select_sql,
+                              columns,
+                              stream_version,
+                              params)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ import pymysql
 import singer
 import tap_mysql
 import tap_mysql.sync_strategies.common as common
+from tap_mysql.connection import MySQLConnection
 
 DB_NAME='tap_mysql_test'
 
@@ -37,7 +38,10 @@ def get_test_connection():
     db_config['database'] = DB_NAME
     db_config['autocommit'] = True
 
-    return pymysql.connect(**db_config)
+    mysql_conn = MySQLConnection(db_config)
+    mysql_conn.autocommit_mode = True
+
+    return mysql_conn
 
 
 def discover_catalog(connection, catalog):


### PR DESCRIPTION
Rather than opening up a connection at the start of the tap and keeping it open for the remainder of execution, open connections as needed. This will prevent issues where there are connection timeouts due to the fact that `LOG_BASED` tables will ultimately use a different connection as `python-mysql-replication` only accepts a connection wrapper.