### PR TITLE
Feature/stream binlog once for all tables

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -332,12 +332,6 @@ def log_engine(mysql_conn, catalog_entry):
                                 catalog_entry.table)
 
 
-def is_selected(stream):
-    table_md = metadata.to_map(stream.metadata).get((), {})
-
-    return table_md.get('selected') or stream.is_selected()
-
-
 def is_valid_currently_syncing_stream(selected_stream):
     stream_metadata = metadata.to_map(selected_stream.metadata)
     replication_method = stream_metadata.get((), {}).get('replication-method')
@@ -430,7 +424,7 @@ def get_non_binlog_streams(mysql_conn, catalog, config, state):
     discovered = discover_catalog(mysql_conn, config)
 
     # Filter catalog to include only selected streams
-    selected_streams = list(filter(lambda s: is_selected(s), catalog.streams))
+    selected_streams = list(filter(lambda s: common.is_selected(s), catalog.streams))
     streams_with_state = []
     streams_without_state = []
 
@@ -471,7 +465,7 @@ def get_non_binlog_streams(mysql_conn, catalog, config, state):
 def get_binlog_streams(mysql_conn, selected_streams, config, state):
     discovered = discover_catalog(mysql_conn, config)
 
-    selected_streams = list(filter(lambda s: is_selected(s), selected_streams.streams))
+    selected_streams = list(filter(lambda s: common.is_selected(s), selected_streams.streams))
     binlog_streams = []
 
 

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -752,12 +752,12 @@ def do_sync(mysql_conn, config, catalog, state):
     binlog_streams = get_binlog_streams(mysql_conn, catalog, config, state)
 
     sync_non_binlog_streams(mysql_conn, non_binlog_streams, config, state)
-    # sync_binlog_streams(mysql_conn, binlog_streams, config, state)
 
-    # if we get here, we've finished processing all the streams, so clear
-    # currently_syncing from the state and emit a state message.
+    # currently_syncing is only used for non-binlog streams
     state = singer.set_currently_syncing(state, None)
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
+
+    # sync_binlog_streams(mysql_conn, binlog_streams, config, state)
 
 
 def log_server_params(mysql_conn):

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -546,11 +546,11 @@ def do_sync_historical_binlog(mysql_conn, config, catalog_entry, state, columns)
     stream_version = common.get_stream_version(catalog_entry.tap_stream_id, state)
 
     if log_file and log_pos and max_pk_values:
-        LOGGER.info("Resuming initial full table sync for LOG_BASED stream %s", catalog_entry.stream)
+        LOGGER.info("Resuming initial full table sync for LOG_BASED stream %s", catalog_entry.tap_stream_id)
         full_table.sync_table(mysql_conn, catalog_entry, state, columns, stream_version)
 
     else:
-        LOGGER.info("Performing initial full table sync for LOG_BASED stream %s", catalog_entry.stream)
+        LOGGER.info("Performing initial full table sync for LOG_BASED stream %s", catalog_entry.tap_stream_id)
 
         state = singer.write_bookmark(state,
                                       catalog_entry.tap_stream_id,

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -340,8 +340,8 @@ def is_valid_currently_syncing_stream(selected_stream, state):
         return True
     elif replication_method == 'LOG_BASED' and binlog_stream_requires_historical(selected_stream, state):
         return True
-    else:
-        return False
+
+    return False
 
 def binlog_stream_requires_historical(catalog_entry, state):
     log_file = singer.get_bookmark(state,
@@ -362,8 +362,8 @@ def binlog_stream_requires_historical(catalog_entry, state):
 
     if (log_file and log_pos) and (not max_pk_values and not last_pk_fetched):
         return False
-    else:
-        return True
+
+    return True
 
 
 def resolve_catalog(discovered_catalog, streams_to_sync):

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -738,8 +738,9 @@ def do_sync(mysql_conn, config, catalog, state):
     state = singer.set_currently_syncing(state, None)
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
-    with metrics.job_timer('sync_binlog') as timer:
-        binlog.sync_binlog_stream(mysql_conn, config, binlog_streams.streams, state)
+    if binlog_streams.streams:
+        with metrics.job_timer('sync_binlog') as timer:
+            binlog.sync_binlog_stream(mysql_conn, config, binlog_streams.streams, state)
 
 
 def log_server_params(mysql_conn):

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -339,7 +339,7 @@ def is_selected(stream):
 
 
 def is_valid_currently_syncing_stream(selected_stream):
-    stream_metadata = metadata.to_map(currently_syncing_stream.metadata)
+    stream_metadata = metadata.to_map(selected_stream.metadata)
     replication_method = stream_metadata.get((), {}).get('replication-method')
 
     if replication_method != 'LOG_BASED':

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -484,6 +484,7 @@ def get_binlog_streams(mysql_conn, catalog, config, state):
 
     return resolve_catalog(discovered, binlog_streams)
 
+
 def write_schema_message(catalog_entry, bookmark_properties=[]):
     key_properties = common.get_key_properties(catalog_entry)
 
@@ -493,6 +494,7 @@ def write_schema_message(catalog_entry, bookmark_properties=[]):
         key_properties=key_properties,
         bookmark_properties=bookmark_properties
     ))
+
 
 def do_sync_incremental(mysql_conn, catalog_entry, state, columns):
     LOGGER.info("Stream %s is using incremental replication", catalog_entry.stream)

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -249,7 +249,7 @@ def discover_catalog(mysql_conn, config):
                     table=table_name,
                     stream=table_name,
                     metadata=metadata.to_list(md_map),
-                    tap_stream_id=table_schema + '-' + table_name,
+                    tap_stream_id=common.generate_tap_stream_id(table_schema, table_name),
                     schema=schema)
 
                 entries.append(entry)

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -728,17 +728,8 @@ def sync_non_binlog_streams(mysql_conn, non_binlog_streams, config, state):
                 raise Exception("only INCREMENTAL, LOG_BASED, and FULL TABLE replication methods are supported")
 
 def sync_binlog_streams(mysql_conn, binlog_streams, config, state):
-    binlog_stream_map = {}
-
-    for catalog_entry in binlog_streams.streams:
-        columns = list(catalog_entry.schema.properties.keys())
-        binlog_stream_map[catalog_entry.tap_stream_id] = {
-            'catalog_entry': catalog_entry,
-            'desired_columns': columns
-        }
-
     # with metrics.job_timer('sync_binlog') as timer:
-    #     binlog.sync_stream(mysql_conn, config, binlog_stream_map, state)
+    #     binlog.sync_binlog_stream(mysql_conn, config, binlog_streams, state)
     return 1
 
 def do_sync(mysql_conn, config, catalog, state):

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -197,7 +197,7 @@ def calculate_bookmark(binlog_streams_map, state):
     for tap_stream_id, bookmark in state.get('bookmarks', {}).items():
         stream = binlog_streams_map.get(tap_stream_id)
 
-        if stream and not common.is_selected(stream['catalog_entry']):
+        if stream and not common.stream_is_selected(stream['catalog_entry']):
             continue
 
         state_log_file = bookmark.get('log_file')

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -170,11 +170,13 @@ def get_older_binlog_location(log_file1, log_pos1, log_file2, log_pos2):
     log_file1_match = re.search('^.*\.(\d+)$', log_file1)
     log_file2_match = re.search('^.*\.(\d+)$', log_file2)
 
-    if log_file1_match and not log_file2_match:
-        return log_file1, log_pos1
+    if not log_file1_match:
+        raise Exception("Unable to replicate binlog stream due to invalid log_file format: {}."
+                        .format(log_file1))
 
-    elif log_file2_match and not log_file1_match:
-        return log_file2, log_pos2
+    elif not log_file2_match:
+        raise Exception("Unable to replicate binlog stream due to invalid log_file format: {}."
+                        .format(log_file2))
 
     elif log_file1_match and log_file2_match:
         log_file1_suffix = int(log_file1_match.groups()[0])

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=duplicate-code,too-many-locals,too-many-arguments
+# pylint: disable=duplicate-code,too-many-locals,too-many-arguments,too-many-branches
 
 import copy
 
@@ -186,8 +186,8 @@ def get_older_binlog_location(log_file1, log_pos1, log_file2, log_pos2):
             return log_file1, log_pos1
         elif (log_file1 == log_file2) and log_pos1 > log_pos2:
             return log_file2, log_pos2
-        else:
-            return log_file2, log_pos2
+
+        return log_file2, log_pos2
 
     return None, None
 
@@ -325,14 +325,6 @@ def sync_binlog_stream(mysql_conn, config, binlog_streams, state):
 
     for tap_stream_id in binlog_streams_map.keys():
         common.whitelist_bookmark_keys(BOOKMARK_KEYS, tap_stream_id, state)
-
-        # TODO: This probably is not necessary
-        # state = singer.write_bookmark(state,
-        #                               tap_stream_id,
-        #                               'version',
-        #                               stream_version)
-
-
 
     log_file, log_pos = calculate_bookmark(binlog_streams_map, state)
 

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -170,11 +170,13 @@ def get_older_binlog_location(log_file1, log_pos1, log_file2, log_pos2):
     log_file1_match = re.search('^.*\.(\d+)$', log_file1)
     log_file2_match = re.search('^.*\.(\d+)$', log_file2)
 
-    if not log_file2_match:
+    if log_file1_match and not log_file2_match:
         return log_file1, log_pos1
-    elif not log_file1_match:
+
+    elif log_file2_match and not log_file1_match:
         return log_file2, log_pos2
-    else:
+
+    elif log_file1_match and log_file2_match:
         log_file1_suffix = int(log_file1_match.groups()[0])
         log_file2_suffix = int(log_file2_match.groups()[0])
 

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -386,8 +386,9 @@ def sync_binlog_stream(mysql_conn, config, binlog_streams, state):
                 events_skipped = events_skipped + 1
 
                 if events_skipped % UPDATE_BOOKMARK_PERIOD == 0:
-                    LOGGER.info("Skipped %s events so far as they were not for selected tables",
-                                events_skipped)
+                    LOGGER.info("Skipped %s events so far as they were not for selected tables; %s rows extracted",
+                                events_skipped,
+                                rows_saved)
 
             elif catalog_entry:
                 initial_binlog_complete = singer.get_bookmark(state,

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -307,7 +307,9 @@ def generate_streams_map(binlog_streams):
     stream_map = {}
 
     for catalog_entry in binlog_streams:
-        columns = list(catalog_entry.schema.properties.keys())
+        columns = add_automatic_properties(catalog_entry,
+                                           list(catalog_entry.schema.properties.keys()))
+
         stream_map[catalog_entry.tap_stream_id] = {
             'catalog_entry': catalog_entry,
             'desired_columns': columns

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -31,10 +31,20 @@ def get_stream_version(tap_stream_id, state):
     return stream_version
 
 
-def is_selected(stream):
-    table_md = metadata.to_map(stream.metadata).get((), {})
+def stream_is_selected(stream):
+    md_map = metadata.to_map(stream.metadata)
+    selected_md = metadata.get(md_map, (), 'selected')
 
-    return table_md.get('selected') or stream.is_selected()
+    return selected_md or stream.is_selected()
+
+
+def property_is_selected(stream, property_name):
+    md_map = metadata.to_map(stream.metadata)
+    selected_md = metadata.get(md_map,
+                               ('properties', property_name),
+                               'selected')
+
+    return selected_md
 
 
 def get_is_view(catalog_entry):

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -28,6 +28,12 @@ def get_stream_version(tap_stream_id, state):
     return stream_version
 
 
+def is_selected(stream):
+    table_md = metadata.to_map(stream.metadata).get((), {})
+
+    return table_md.get('selected') or stream.is_selected()
+
+
 def get_is_view(catalog_entry):
     md_map = metadata.to_map(catalog_entry.metadata)
 

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -44,7 +44,14 @@ def property_is_selected(stream, property_name):
                                ('properties', property_name),
                                'selected')
 
-    return selected_md
+    selected_by_default_md = metadata.get(md_map,
+                               ('properties', property_name),
+                               'selected-by-default')
+
+    if selected_md is False:
+        return False
+
+    return selected_md or selected_by_default_md
 
 
 def get_is_view(catalog_entry):

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -19,6 +19,9 @@ def escape(string):
     return '`' + string + '`'
 
 
+def generate_tap_stream_id(table_schema, table_name):
+    return table_schema + '-' + table_name
+
 def get_stream_version(tap_stream_id, state):
     stream_version = singer.get_bookmark(state, tap_stream_id, 'version')
 

--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -90,10 +90,16 @@ class BinlogInterruption(unittest.TestCase):
         self.catalog = init_tables(self.conn)
 
         for stream in self.catalog.streams:
-            stream.schema.selected = True
-            stream.key_properties = []
-            stream.schema.properties['foo'].selected = True
-            stream.schema.properties['bar'].selected = True
+            stream.metadata = [
+                {'breadcrumb': (),
+                 'metadata': {'selected': True,
+                              'database-name': 'tap_mysql_test',
+                              'table-key-properties': ['id']}},
+                {'breadcrumb': ('properties', 'id'), 'metadata': {'selected': True}},
+                {'breadcrumb': ('properties', 'foo'), 'metadata': {'selected': True}},
+                {'breadcrumb': ('properties', 'bar'), 'metadata': {'selected': True}},
+            ]
+
             stream.stream = stream.table
 
             if stream.table == 'table_2':
@@ -231,10 +237,16 @@ class FullTableInterruption(unittest.TestCase):
         self.catalog = init_tables(self.conn)
 
         for stream in self.catalog.streams:
-            stream.schema.selected = True
-            stream.key_properties = []
-            stream.schema.properties['foo'].selected = True
-            stream.schema.properties['bar'].selected = True
+            stream.metadata = [
+                {'breadcrumb': (),
+                 'metadata': {'selected': True,
+                              'database-name': 'tap_mysql_test',
+                              'table-key-properties': ['id']}},
+                {'breadcrumb': ('properties', 'id'), 'metadata': {'selected': True}},
+                {'breadcrumb': ('properties', 'foo'), 'metadata': {'selected': True}},
+                {'breadcrumb': ('properties', 'bar'), 'metadata': {'selected': True}},
+            ]
+
             stream.stream = stream.table
             test_utils.set_replication_method_and_key(stream, 'FULL_TABLE', None)
 

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -321,6 +321,9 @@ class TestCurrentStream(unittest.TestCase):
             'bookmarks': {
                 'tap_mysql_test-a': {
                     'version': 123
+                },
+                'tap_mysql_test-b': {
+                    'version': 456
                 }
             }
         }
@@ -819,6 +822,6 @@ class TestUnsupportedPK(unittest.TestCase):
 
 
 if __name__== "__main__":
-    test1 = TestEscaping()
+    test1 = TestCurrentStream()
     test1.setUp()
-    test1.runTest()
+    test1.test_start_at_currently_syncing()

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -704,7 +704,6 @@ class TestBinlogReplication(unittest.TestCase):
         record_messages = list(filter(lambda m: isinstance(m, singer.RecordMessage), SINGER_MESSAGES))
 
         message_types = [type(m) for m in SINGER_MESSAGES]
-
         self.assertEqual(message_types,
                          [singer.StateMessage,
                           singer.SchemaMessage,
@@ -720,12 +719,26 @@ class TestBinlogReplication(unittest.TestCase):
                           singer.RecordMessage,
                           singer.StateMessage])
 
-        self.assertEqual([(1, False), (2, False), (3, False), (3, False), (2, True)],
-                         [(m.record['id'], m.record.get(binlog.SDC_DELETED_AT) is not None)
+        self.assertEqual([('binlog_1', 1, '2017-06-01T00:00:00+00:00', False),
+                          ('binlog_1', 2, '2017-06-20T00:00:00+00:00', False),
+                          ('binlog_1', 3, '2017-09-22T00:00:00+00:00', False),
+                          ('binlog_2', 1, '2017-10-22T00:00:00+00:00', False),
+                          ('binlog_2', 2, '2017-11-10T00:00:00+00:00', False),
+                          ('binlog_1', 3, '2018-06-18T00:00:00+00:00', False),
+                          ('binlog_2', 2, '2018-06-18T00:00:00+00:00', False),
+                          ('binlog_1', 2, '2017-06-20T00:00:00+00:00', True),
+                          ('binlog_2', 1, '2017-10-22T00:00:00+00:00', True)],
+                         [(m.stream,
+                           m.record['id'],
+                           m.record['updated'],
+                           m.record.get(binlog.SDC_DELETED_AT) is not None)
                           for m in record_messages])
 
-        self.assertIsNotNone(singer.get_bookmark(self.state, 'tap_mysql_test-binlog', 'log_file'))
-        self.assertIsNotNone(singer.get_bookmark(self.state, 'tap_mysql_test-binlog', 'log_pos'))
+        self.assertIsNotNone(singer.get_bookmark(self.state, 'tap_mysql_test-binlog_1', 'log_file'))
+        self.assertIsNotNone(singer.get_bookmark(self.state, 'tap_mysql_test-binlog_1', 'log_pos'))
+
+        self.assertIsNotNone(singer.get_bookmark(self.state, 'tap_mysql_test-binlog_2', 'log_file'))
+        self.assertIsNotNone(singer.get_bookmark(self.state, 'tap_mysql_test-binlog_2', 'log_pos'))
 
 
 class TestViews(unittest.TestCase):

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -821,7 +821,140 @@ class TestUnsupportedPK(unittest.TestCase):
 
 
 
+class TestCalculateBinlogBookmark(unittest.TestCase):
+    def setUp(self):
+        self.conn = test_utils.get_test_connection()
+
+        with connect_with_backoff(self.conn) as open_conn:
+            with open_conn.cursor() as cursor:
+                cursor.execute('CREATE TABLE a (val int)')
+                cursor.execute('CREATE TABLE b (val int)')
+                cursor.execute('CREATE TABLE c (val int)')
+                cursor.execute('CREATE TABLE d (val int)')
+                cursor.execute('INSERT INTO a (val) VALUES (1)')
+                cursor.execute('INSERT INTO b (val) VALUES (1)')
+                cursor.execute('INSERT INTO c (val) VALUES (1)')
+                cursor.execute('INSERT INTO d (val) VALUES (1)')
+
+        self.catalog = test_utils.discover_catalog(self.conn, {})
+
+        for stream in self.catalog.streams:
+            stream.key_properties = []
+            stream.schema.properties['val'].selected = True
+            stream.stream = stream.table
+            if stream.stream != 'd':
+                stream.schema.selected = True
+            test_utils.set_replication_method_and_key(stream, 'LOG_BASED', None)
+
+
+        self.binlog_streams_map = binlog.generate_streams_map(self.catalog.streams)
+
+    def test_no_state(self):
+        state = {}
+
+        log_file, log_pos = binlog.calculate_bookmark(state)
+        self.assertIsNone(log_file)
+        self.assertIsNone(log_pos)
+
+
+    def test_no_valid_log_filenames(self):
+        state = {
+            'bookmarks': {
+                'tap_mysql_test-a': {
+                    'log_file': 'asdf',
+                    'log_pos': 10,
+                },
+                'tap_mysql_test-b': {
+                    'log_file': 'qwerty',
+                    'log_pos': 10,
+                }
+            }
+        }
+
+        log_file, log_pos = binlog.calculate_bookmark(self.binlog_streams_map, state)
+
+        self.assertIsNone(log_file)
+        self.assertIsNone(log_pos)
+
+
+    def test_no_valid_log_filenames(self):
+        state = {
+            'bookmarks': {
+                'tap_mysql_test-a': {
+                    'log_file': 'asdf',
+                    'log_pos': 10,
+                },
+                'tap_mysql_test-b': {
+                    'log_file': 'qwerty',
+                    'log_pos': 10,
+                }
+            }
+        }
+
+        log_file, log_pos = binlog.calculate_bookmark(self.binlog_streams_map, state)
+        self.assertIsNone(log_file)
+        self.assertIsNone(log_pos)
+
+
+    def test_all_log_filenames_differ(self):
+        expected_log_file = 'mysql-bin.000316'
+        expected_log_pos = 400
+
+        state = {
+            'bookmarks': {
+                'tap_mysql_test-a': {
+                    'log_file': 'mysql-bin.000321',
+                    'log_pos': 100,
+                },
+                'tap_mysql_test-b': {
+                    'log_file': expected_log_file,
+                    'log_pos': expected_log_pos,
+                },
+                'tap_mysql_test-3': {
+                    'log_file': 'mysql-bin.000343',
+                    'log_pos': 124,
+                }
+            }
+        }
+
+        log_file, log_pos = binlog.calculate_bookmark(self.binlog_streams_map,state)
+
+        self.assertEqual(log_file, expected_log_file)
+        self.assertEqual(log_pos, expected_log_pos)
+
+
+    def test_oldest_is_not_selected(self):
+        expected_log_file = 'mysql-bin.000316'
+        expected_log_pos = 400
+
+        state = {
+            'bookmarks': {
+                'tap_mysql_test-a': {
+                    'log_file': 'mysql-bin.000321',
+                    'log_pos': 100,
+                },
+                'tap_mysql_test-b': {
+                    'log_file': expected_log_file,
+                    'log_pos': expected_log_pos,
+                },
+                'tap_mysql_test-c': {
+                    'log_file': 'mysql-bin.000343',
+                    'log_pos': 124,
+                },
+                'tap_mysql_test-d': {
+                    'log_file': 'mysql-bin.000001',
+                    'log_pos': 4,
+                }
+            }
+        }
+
+        log_file, log_pos = binlog.calculate_bookmark(self.binlog_streams_map,state)
+
+        self.assertEqual(log_file, expected_log_file)
+        self.assertEqual(log_pos, expected_log_pos)
+
+
 if __name__== "__main__":
-    test1 = TestCurrentStream()
+    test1 = TestCalculateBinlogBookmark()
     test1.setUp()
-    test1.test_start_at_currently_syncing()
+    test1.test_oldest_is_not_selected()

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -262,8 +262,11 @@ class TestSchemaMessages(unittest.TestCase):
 
         catalog = test_utils.discover_catalog(conn, {})
         catalog.streams[0].stream = 'tab'
-        catalog.streams[0].schema.selected = True
-        catalog.streams[0].schema.properties['a'].selected = True
+        catalog.streams[0].metadata = [
+            {'breadcrumb': (), 'metadata': {'selected': True, 'database-name': 'tap_mysql_test'}},
+            {'breadcrumb': ('properties', 'a'), 'metadata': {'selected': True}}
+        ]
+
         test_utils.set_replication_method_and_key(catalog.streams[0], 'FULL_TABLE', None)
 
         global SINGER_MESSAGES
@@ -300,9 +303,13 @@ class TestCurrentStream(unittest.TestCase):
         self.catalog = test_utils.discover_catalog(self.conn, {})
 
         for stream in self.catalog.streams:
-            stream.schema.selected = True
             stream.key_properties = []
-            stream.schema.properties['val'].selected = True
+
+            stream.metadata = [
+                {'breadcrumb': (), 'metadata': {'selected': True, 'database-name': 'tap_mysql_test'}},
+                {'breadcrumb': ('properties', 'val'), 'metadata': {'selected': True}}
+            ]
+
             stream.stream = stream.table
             test_utils.set_replication_method_and_key(stream, 'FULL_TABLE', None)
 
@@ -357,9 +364,13 @@ class TestStreamVersionFullTable(unittest.TestCase):
 
         self.catalog = test_utils.discover_catalog(self.conn, {})
         for stream in self.catalog.streams:
-            stream.schema.selected = True
             stream.key_properties = []
-            stream.schema.properties['val'].selected = True
+
+            stream.metadata = [
+                {'breadcrumb': (), 'metadata': {'selected': True, 'database-name': 'tap_mysql_test'}},
+                {'breadcrumb': ('properties', 'val'), 'metadata': {'selected': True}}
+            ]
+
             stream.stream = stream.table
             test_utils.set_replication_method_and_key(stream, 'FULL_TABLE', None)
 
@@ -371,6 +382,7 @@ class TestStreamVersionFullTable(unittest.TestCase):
         tap_mysql.do_sync(self.conn, {}, self.catalog, state)
 
         (message_types, versions) = message_types_and_versions(SINGER_MESSAGES)
+
         self.assertEqual(['ActivateVersionMessage', 'RecordMessage', 'ActivateVersionMessage'], message_types)
         self.assertTrue(isinstance(versions[0], int))
         self.assertEqual(versions[0], versions[1])
@@ -463,9 +475,12 @@ class TestIncrementalReplication(unittest.TestCase):
         self.catalog = test_utils.discover_catalog(self.conn, {})
 
         for stream in self.catalog.streams:
-            stream.schema.selected = True
             stream.key_properties = []
-            stream.schema.properties['val'].selected = True
+            stream.metadata = [
+                {'breadcrumb': (), 'metadata': {'selected': True, 'database-name': 'tap_mysql_test'}},
+                {'breadcrumb': ('properties', 'val'), 'metadata': {'selected': True}}
+            ]
+
             stream.stream = stream.table
             test_utils.set_replication_method_and_key(stream, 'INCREMENTAL', 'updated')
 
@@ -540,7 +555,13 @@ class TestIncrementalReplication(unittest.TestCase):
         stream = [x for x in self.catalog.streams if x.stream == 'incremental'][0]
 
         test_utils.set_replication_method_and_key(stream, 'INCREMENTAL', 'val')
-        stream.schema.properties['updated'].selected = True
+
+        stream.metadata = [
+            {'breadcrumb': (), 'metadata': {'selected': True, 'database-name': 'tap_mysql_test'}},
+            {'breadcrumb': ('properties', 'val'), 'metadata': {'selected': True}},
+            {'breadcrumb': ('properties', 'updated'), 'metadata': {'selected': True}}
+        ]
+
         tap_mysql.do_sync(self.conn, {}, self.catalog, state)
 
         self.assertEqual(state['bookmarks']['tap_mysql_test-incremental']['replication_key'], 'val')
@@ -797,9 +818,12 @@ class TestEscaping(unittest.TestCase):
         self.catalog = test_utils.discover_catalog(self.conn, {})
 
         self.catalog.streams[0].stream = 'some_stream_name'
-        self.catalog.streams[0].schema.selected = True
         self.catalog.streams[0].key_properties = []
-        self.catalog.streams[0].schema.properties['b c'].selected = True
+
+        stream.metadata = [
+            {'breadcrumb': (), 'metadata': {'selected': True, 'database-name': 'tap_mysql_test'}},
+            {'breadcrumb': ('properties', 'b c'), 'metadata': {'selected': True}}
+        ]
 
         test_utils.set_replication_method_and_key(self.catalog.streams[0], 'FULL_TABLE', None)
 
@@ -856,10 +880,14 @@ class TestCalculateBinlogBookmark(unittest.TestCase):
 
         for stream in self.catalog.streams:
             stream.key_properties = []
-            stream.schema.properties['val'].selected = True
+
             stream.stream = stream.table
             if stream.stream != 'd':
-                stream.schema.selected = True
+                stream.metadata = [
+                    {'breadcrumb': (), 'metadata': {'selected': True, 'database-name': 'tap_mysql_test'}},
+                    {'breadcrumb': ('properties', 'val'), 'metadata': {'selected': True}}
+                ]
+
             test_utils.set_replication_method_and_key(stream, 'LOG_BASED', None)
 
 

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -972,9 +972,36 @@ class TestCalculateBinlogBookmark(unittest.TestCase):
             }
         }
 
-        log_file, log_pos = binlog.calculate_bookmark(self.binlog_streams_map, state)
-        self.assertIsNone(log_file)
-        self.assertIsNone(log_pos)
+        failed = False
+
+        try:
+            binlog.calculate_bookmark(self.binlog_streams_map, state)
+        except Exception as ex:
+            failed = True
+        self.assertTrue(failed)
+
+
+    def test_some_valid_log_filenames(self):
+        state = {
+            'bookmarks': {
+                'tap_mysql_test-a': {
+                    'log_file': 'mysql-bin.000316',
+                    'log_pos': 10,
+                },
+                'tap_mysql_test-b': {
+                    'log_file': 'qwerty',
+                    'log_pos': 10,
+                }
+            }
+        }
+
+        failed = False
+
+        try:
+            binlog.calculate_bookmark(self.binlog_streams_map, state)
+        except Exception as ex:
+            failed = True
+        self.assertTrue(failed)
 
 
     def test_all_log_filenames_differ(self):


### PR DESCRIPTION
The crux of this PR is to stream over the binlog once for all tables. Priority will be given to non-binlog streams. This set includes all streams set to use `INCREMENTAL` or `FULL_TABLE` along with `LOG_BASED` streams that need to begin or continue a historical sync.