### PR TITLE
no longer use initial_binlog_complete state for LOG_BASED replication

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -338,7 +338,8 @@ def is_valid_currently_syncing_stream(selected_stream, state):
 
     if replication_method != 'LOG_BASED':
         return True
-    elif replication_method == 'LOG_BASED' and binlog_stream_requires_historical(selected_stream, state):
+
+    if replication_method == 'LOG_BASED' and binlog_stream_requires_historical(selected_stream, state):
         return True
 
     return False
@@ -383,8 +384,8 @@ def resolve_catalog(discovered_catalog, streams_to_sync):
                            database_name, catalog_entry.table)
             continue
 
-        selected = set([k for k, v in catalog_entry.schema.properties.items()
-                        if common.property_is_selected(catalog_entry, k) or k == replication_key])
+        selected = {k for k, v in catalog_entry.schema.properties.items()
+                        if common.property_is_selected(catalog_entry, k) or k == replication_key}
 
         # These are the columns we need to select
         columns = desired_columns(selected, discovered_table.schema)

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -203,7 +203,7 @@ def calculate_bookmark(mysql_conn, binlog_streams_map, state):
             binary_logs = cur.fetchall()
 
             if binary_logs:
-                server_logs_set = set([log[0] for log in binary_logs])
+                server_logs_set = {log[0] for log in binary_logs}
                 state_logs_set = set(min_log_pos_per_file.keys())
                 expired_logs = state_logs_set.difference(server_logs_set)
 


### PR DESCRIPTION
Now that the binlog is streamed through once for all tables, the `initial_binlog_complete` state logic is no longer necessary.