### PR TITLE
use server_id for binlog stream from config if provided

### DIFF
--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -327,7 +327,12 @@ def sync_binlog_stream(mysql_conn, config, binlog_streams, state):
 
     verify_log_file_exists(mysql_conn, log_file, log_pos)
 
-    server_id = fetch_server_id(mysql_conn)
+    if config.get('server_id'):
+        server_id = int(config.get('server_id'))
+        LOGGER.info("Using provided server_id=%s", server_id)
+    else:
+        server_id = fetch_server_id(mysql_conn)
+        LOGGER.info("No server_id provided, will use global server_id=%s", server_id)
 
     connection_wrapper = make_connection_wrapper(config)
 

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -749,7 +749,10 @@ class TestBinlogReplication(unittest.TestCase):
         global SINGER_MESSAGES
         SINGER_MESSAGES.clear()
 
-        tap_mysql.do_sync(self.conn, test_utils.get_db_config(), self.catalog, self.state)
+        config = test_utils.get_db_config()
+        config['server_id'] = "100"
+
+        tap_mysql.do_sync(self.conn, config, self.catalog, self.state)
         record_messages = list(filter(lambda m: isinstance(m, singer.RecordMessage), SINGER_MESSAGES))
 
         message_types = [type(m) for m in SINGER_MESSAGES]


### PR DESCRIPTION
Previously, the tap simply used `@@server_id` as the `server_id` used to replicate the binlog stream. This is an issue if the tap is either connecting to a replication slave or if multiple instances of the tap are running against the same server. The `server_id` can now be overridden within the config.