### PR TITLE
Log server SSL params

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -693,12 +693,13 @@ def log_server_params(mysql_conn):
             with open_conn.cursor() as cur:
                 cur.execute('''
                 show session status where Variable_name IN ('Ssl_version', 'Ssl_cipher')''')
-                row = cur.fetchall()
-                print(row)
+                rows = cur.fetchall()
+                mapped_row = {k:v for (k,v) in [(r[0], r[1]) for r in rows]}
                 LOGGER.info('Server SSL Parameters (blank means SSL is not active): ' +
                             '[ssl_version: %s], ' +
                             '[ssl_cipher: %s]',
-                            row[0][1], row[1][1])
+                            mapped_row['Ssl_version'],
+                            mapped_row['Ssl_cipher'])
 
         except pymysql.err.InternalError as e:
             LOGGER.warning("Encountered error checking server params. Error: (%s) %s", *e.args)

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -674,8 +674,8 @@ def do_sync(mysql_conn, config, catalog, state):
 
 def log_server_params(mysql_conn):
     with connect_with_backoff(mysql_conn) as open_conn:
-        with open_conn.cursor() as cur:
-            try:
+        try:
+            with open_conn.cursor() as cur:
                 cur.execute('''
                 SELECT VERSION() as version,
                        @@session.wait_timeout as wait_timeout,
@@ -690,8 +690,18 @@ def log_server_params(mysql_conn):
                             'max_allowed_packet: %s, ' +
                             'interactive_timeout: %s',
                             *row)
-            except pymysql.err.InternalError as e:
-                LOGGER.warning("Encountered error checking server params. Error: (%s) %s", *e.args)
+            with open_conn.cursor() as cur:
+                cur.execute('''
+                show session status where Variable_name IN ('Ssl_version', 'Ssl_cipher')''')
+                row = cur.fetchall()
+                print(row)
+                LOGGER.info('Server SSL Parameters (blank means SSL is not active): ' +
+                            '[ssl_version: %s], ' +
+                            '[ssl_cipher: %s]',
+                            row[0][1], row[1][1])
+
+        except pymysql.err.InternalError as e:
+            LOGGER.warning("Encountered error checking server params. Error: (%s) %s", *e.args)
 
 
 def main_impl():


### PR DESCRIPTION
Tested against MySQL 5.6.33 w/o SSL:

```
INFO Server Parameters: version: 5.6.33-0ubuntu0.14.04.1, wait_timeout: 2700, innodb_lock_wait_timeout: 2700, max_allowed_packet: 16777216, interactive_timeout: 28800
INFO Server SSL Parameters (blank means SSL is not active): [ssl_version: ], [ssl_cipher: ]
```

and w/ SSL:

```
INFO Attempting SSL connection
INFO Server Parameters: version: 5.6.33-0ubuntu0.14.04.1, wait_timeout: 2700, innodb_lock_wait_timeout: 2700, max_allowed_packet: 16777216, interactive_timeout: 28800
INFO Server SSL Parameters (blank means SSL is not active): [ssl_version: TLSv1], [ssl_cipher: DHE-RSA-AES256-SHA]
```