### PR TITLE
escape percent signs

### DIFF
--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -83,6 +83,8 @@ def generate_select_sql(catalog_entry, columns):
         escaped_db,
         escaped_table)
 
+    # escape percent signs
+    select_sql = select_sql.replace('%', '%%')
     return select_sql
 
 


### PR DESCRIPTION
tap-mysql was hitting errors when columns had percent signs in them since pymysql was interpreting them as string formatters.  

Replacing `%` with `%%` resolves the error.