### PR TITLE
Exclude sys schema when discovering catalog

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -156,7 +156,8 @@ def discover_catalog(mysql_conn, config):
         WHERE table_schema NOT IN (
         'information_schema',
         'performance_schema',
-        'mysql'
+        'mysql',
+        'sys'
         )"""
 
     with connect_with_backoff(mysql_conn) as open_conn:


### PR DESCRIPTION
[Sys schema](https://dev.mysql.com/doc/refman/5.7/en/sys-schema.html) added to mysql 5.7.7 and running the tap in discovery mode adds some noise. This PR is excluding to gather information `sys` schema
  