### PR TITLE
Feature/allow varchar pks for full table

### DIFF
--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=duplicate-code,too-many-locals,simplifiable-if-expression
+# pylint: disable=duplicate-code,too-many-locals,simplifiable-if-expression,too-many-arguments
 
 import copy
 import singer
@@ -96,8 +96,8 @@ def pks_are_integer_or_varchar(mysql_conn, config, catalog_entry):
                         return False
 
         return True
-    else:
-        return False
+
+    return False
 
 
 

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -58,6 +58,49 @@ def pks_are_auto_incrementing(mysql_conn, catalog_entry):
     return True
 
 
+def pks_are_integer_or_varchar(mysql_conn, config, catalog_entry):
+    database_name = common.get_database_name(catalog_entry)
+    key_properties = common.get_key_properties(catalog_entry)
+
+    if config.get('allow_non_auto_increment_pks') and key_properties:
+        valid_column_types = set([
+            'tinyint',
+            'smallint'
+            'mediumint',
+            'int',
+            'bigint',
+            'varchar'
+        ])
+
+
+        sql = """SELECT data_type
+                   FROM information_schema.columns
+                  WHERE table_schema = '{}'
+                    AND table_name = '{}'
+                    AND column_name = '{}'
+        """
+
+        with connect_with_backoff(mysql_conn) as open_conn:
+            with open_conn.cursor() as cur:
+                for pk in key_properties:
+                    cur.execute(sql.format(database_name,
+                                              catalog_entry.table,
+                                              pk))
+
+                    result = cur.fetchone()
+
+                    if not result:
+                        raise Exception("Primary key column {} does not exist.".format(pk))
+
+                    if result[0] not in valid_column_types:
+                        return False
+
+        return True
+    else:
+        return False
+
+
+
 def get_max_pk_values(cursor, catalog_entry):
     database_name = common.get_database_name(catalog_entry)
     escaped_db = common.escape(database_name)
@@ -103,24 +146,58 @@ def generate_pk_clause(catalog_entry, state):
                                           catalog_entry.tap_stream_id,
                                           'last_pk_fetched')
 
+    pk_comparisons = []
+
     if last_pk_fetched:
-        pk_comparisons = ["({} > {} AND {} <= {})".format(common.escape(pk),
-                                                          last_pk_fetched[pk],
-                                                          common.escape(pk),
-                                                          max_pk_values[pk])
-                          for pk in key_properties]
+        for pk in key_properties:
+            column_type = catalog_entry.schema.properties.get(pk).type
+
+            # quote last/max PK val if column is VARCHAR
+            if 'string' in column_type:
+                last_pk_val = "'" + last_pk_fetched[pk] + "'"
+                max_pk_val = "'" + max_pk_values[pk] + "'"
+            else:
+                last_pk_val = last_pk_fetched[pk]
+                max_pk_val = max_pk_values[pk]
+
+            pk_comparisons.append("({} > {} AND {} <= {})".format(common.escape(pk),
+                                                                  last_pk_val,
+                                                                  common.escape(pk),
+                                                                  max_pk_val))
     else:
-        pk_comparisons = ["{} <= {}".format(common.escape(pk), max_pk_values[pk])
-                          for pk in key_properties]
+        for pk in key_properties:
+            column_type = catalog_entry.schema.properties.get(pk).type
+
+            # quote last/max PK val if column is VARCHAR
+            if 'string' in column_type:
+                pk_val = "'" + max_pk_values[pk] + "'"
+            else:
+                pk_val = max_pk_values[pk]
+
+            pk_comparisons.append("{} <= {}".format(common.escape(pk), pk_val))
 
     sql = " WHERE {} ORDER BY {} ASC".format(" AND ".join(pk_comparisons),
                                              ", ".join(escaped_columns))
 
     return sql
 
+def update_incremental_full_table_state(catalog_entry, state, cursor):
+    max_pk_values = singer.get_bookmark(state,
+                                        catalog_entry.tap_stream_id,
+                                        'max_pk_values') or get_max_pk_values(cursor, catalog_entry)
 
 
-def sync_table(mysql_conn, catalog_entry, state, columns, stream_version):
+    if not max_pk_values:
+        LOGGER.info("No max value for PK found for table {}".format(catalog_entry.table))
+    else:
+        state = singer.write_bookmark(state,
+                                      catalog_entry.tap_stream_id,
+                                      'max_pk_values',
+                                      max_pk_values)
+
+    return state
+
+def sync_table(mysql_conn, config, catalog_entry, state, columns, stream_version):
     common.whitelist_bookmark_keys(generate_bookmark_keys(catalog_entry), catalog_entry.tap_stream_id, state)
 
     bookmark = state.get('bookmarks', {}).get(catalog_entry.tap_stream_id, {})
@@ -146,31 +223,30 @@ def sync_table(mysql_conn, catalog_entry, state, columns, stream_version):
 
     key_props_are_auto_incrementing = pks_are_auto_incrementing(mysql_conn, catalog_entry)
 
+    allow_non_auto_incrementing_pk = pks_are_integer_or_varchar(mysql_conn,
+                                                                      config,
+                                                                      catalog_entry)
+    pk_clause = ""
+
     with connect_with_backoff(mysql_conn) as open_conn:
         with open_conn.cursor() as cur:
             select_sql = common.generate_select_sql(catalog_entry, columns)
 
             if key_props_are_auto_incrementing:
                 LOGGER.info("Detected auto-incrementing primary key(s) - will replicate incrementally")
-                max_pk_values = singer.get_bookmark(state,
-                                                    catalog_entry.tap_stream_id,
-                                                    'max_pk_values') or get_max_pk_values(cur, catalog_entry)
 
+                state = update_incremental_full_table_state(catalog_entry, state, cur)
+                pk_clause = generate_pk_clause(catalog_entry, state)
+            elif allow_non_auto_incrementing_pk:
+                LOGGER.info("Allowing non-auto-incrementing primary key(s) - will replicate incrementally")
 
-                if not max_pk_values:
-                    LOGGER.info("No max value for auto-incrementing PK found for table {}".format(catalog_entry.table))
-                else:
-                    state = singer.write_bookmark(state,
-                                                  catalog_entry.tap_stream_id,
-                                                  'max_pk_values',
-                                                  max_pk_values)
+                state = update_incremental_full_table_state(catalog_entry, state, cur)
+                pk_clause = generate_pk_clause(catalog_entry, state)
 
-                    pk_clause = generate_pk_clause(catalog_entry, state)
-
-                    select_sql += pk_clause
-
+            select_sql += pk_clause
             params = {}
 
+            # common.sync_query(cur, catalog_entry, state, select_sql, columns, stream_version, params)
             common.sync_query(cur,
                               catalog_entry,
                               state,

--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -25,6 +25,11 @@ TABLE_1_DATA = [[ 100, 'abc' ],
 
 TABLE_2_DATA = TABLE_1_DATA[::-1]
 
+#                ID, FOO   BAR
+TABLE_3_DATA = [[ "turkey",     100, 'abc' ],
+                [ "chicken-2",  200, 'def' ],
+                [ "chicken-11", 300, 'ghi' ]]
+
 def insert_record(conn, table_name, record):
     value_sql = ",".join(["%s" for i in range(len(record))])
 
@@ -40,6 +45,20 @@ def insert_record(conn, table_name, record):
         with open_conn.cursor() as cur:
             cur.execute(insert_sql, record)
 
+def insert_record_with_specific_id(conn, table_name, record):
+        value_sql = ",".join(["%s" for i in range(len(record))])
+
+        insert_sql = """
+            INSERT INTO {}.{}
+                   ( `id`, `foo`, `bar` )
+            VALUES ( {} )""".format(
+                test_utils.DB_NAME,
+                table_name,
+                value_sql)
+
+        with connect_with_backoff(conn) as open_conn:
+            with open_conn.cursor() as cur:
+                cur.execute(insert_sql, record)
 
 def singer_write_message_no_table_2(message):
     global TABLE_2_RECORD_COUNT
@@ -48,6 +67,18 @@ def singer_write_message_no_table_2(message):
         TABLE_2_RECORD_COUNT = TABLE_2_RECORD_COUNT + 1
 
         if TABLE_2_RECORD_COUNT > 1:
+            raise Exception("simulated exception")
+
+    SINGER_MESSAGES.append(message)
+
+
+def singer_write_message_no_table_3(message):
+    global TABLE_3_RECORD_COUNT
+
+    if isinstance(message, singer.RecordMessage) and message.stream == 'table_3':
+        TABLE_3_RECORD_COUNT = TABLE_3_RECORD_COUNT + 1
+
+        if TABLE_3_RECORD_COUNT > 1:
             raise Exception("simulated exception")
 
     SINGER_MESSAGES.append(message)
@@ -73,11 +104,21 @@ def init_tables(conn):
             bar VARCHAR(10)
             )""")
 
+            cur.execute("""
+            CREATE TABLE table_3 (
+            id  VARCHAR(32) PRIMARY KEY,
+            foo BIGINT,
+            bar VARCHAR(10)
+            )""")
+
     for record in TABLE_1_DATA:
         insert_record(conn, 'table_1', record)
 
     for record in TABLE_2_DATA:
         insert_record(conn, 'table_2', record)
+
+    for record in TABLE_3_DATA:
+        insert_record_with_specific_id(conn, 'table_3', record)
 
     catalog = test_utils.discover_catalog(conn, {})
 
@@ -102,13 +143,16 @@ class BinlogInterruption(unittest.TestCase):
 
             stream.stream = stream.table
 
-            if stream.table == 'table_2':
+            if stream.table == 'table_2' or stream.table == 'table_3':
                 test_utils.set_replication_method_and_key(stream, 'LOG_BASED', None)
             else:
                 test_utils.set_replication_method_and_key(stream, 'FULL_TABLE', None)
 
         global TABLE_2_RECORD_COUNT
         TABLE_2_RECORD_COUNT = 0
+
+        global TABLE_3_RECORD_COUNT
+        TABLE_3_RECORD_COUNT = 0
 
         global SINGER_MESSAGES
         SINGER_MESSAGES.clear()
@@ -118,6 +162,16 @@ class BinlogInterruption(unittest.TestCase):
 
         state = {}
         failed_syncing_table_2 = False
+
+        # Do not worry about table_3
+        for stream in filter(lambda s: s.stream == 'table_3', self.catalog.streams):
+            md_map = singer.metadata.to_map(stream.metadata)
+            md_map = singer.metadata.write(md_map,
+                                    (),
+                                    'selected',
+                                    False)
+
+            stream.metadata = singer.metadata.to_list(md_map)
 
         try:
             tap_mysql.do_sync(self.conn, test_utils.get_db_config(), self.catalog, state)
@@ -230,6 +284,138 @@ class BinlogInterruption(unittest.TestCase):
         self.assertIsNotNone(table_2_bookmark.get('log_file'))
         self.assertIsNotNone(table_2_bookmark.get('log_pos'))
 
+    def test_table_3_interrupted(self):
+        singer.write_message = singer_write_message_no_table_3
+
+        state = {}
+        failed_syncing_table_3 = False
+
+        # Do not worry about table_2
+        for stream in filter(lambda s: s.stream == 'table_2', self.catalog.streams):
+            md_map = singer.metadata.to_map(stream.metadata)
+            md_map = singer.metadata.write(md_map,
+                                    (),
+                                    'selected',
+                                    False)
+
+            stream.metadata = singer.metadata.to_list(md_map)
+
+        config = test_utils.get_db_config()
+        config['allow_non_auto_increment_pks'] = True
+
+        try:
+            tap_mysql.do_sync(self.conn, config, self.catalog, state)
+        except Exception as ex:
+            if str(ex) == 'simulated exception':
+                failed_syncing_table_3 = True
+
+        self.assertTrue(failed_syncing_table_3)
+
+        record_messages_1 = [[m.stream, m.record] for m in SINGER_MESSAGES
+                             if isinstance(m, singer.RecordMessage)]
+
+        # sorting of the two chicken-* columns is based on lexicographic ordering which in
+        # this case chicken-11 comes before chicken-2
+        self.assertEqual(record_messages_1,
+                         [['table_1', {'id': 1,            'bar': 'abc', 'foo': 100}],
+                          ['table_1', {'id': 2,            'bar': 'def', 'foo': 200}],
+                          ['table_1', {'id': 3,            'bar': 'ghi', 'foo': 300}],
+                          ['table_3', {'id': "chicken-11", 'bar': 'ghi', 'foo': 300}]])
+
+        self.assertEqual(state['currently_syncing'], 'tap_mysql_test-table_3')
+
+        table_1_bookmark = state['bookmarks']['tap_mysql_test-table_1']
+        table_3_bookmark = state['bookmarks']['tap_mysql_test-table_3']
+
+        self.assertEqual(table_1_bookmark,
+                         {'initial_full_table_complete': True})
+
+        self.assertIsNone(table_3_bookmark.get('initial_full_table_complete'))
+
+        table_3_version = table_3_bookmark['version']
+        self.assertIsNotNone(table_3_version)
+
+        self.assertEqual(table_3_bookmark['max_pk_values'],   {'id': "turkey"})
+        self.assertEqual(table_3_bookmark['last_pk_fetched'], {'id': "chicken-11"})
+
+        self.assertIsNotNone(table_3_bookmark.get('log_file'))
+        self.assertIsNotNone(table_3_bookmark.get('log_pos'))
+
+        failed_syncing_table_3 = False
+        singer.write_message = singer_write_message_ok
+
+        table_3_RECORD_COUNT = 0
+        SINGER_MESSAGES.clear()
+
+        tap_mysql.do_sync(self.conn, config, self.catalog, state)
+
+        self.assertFalse(failed_syncing_table_3)
+
+        record_messages_2 = [[m.stream, m.record] for m in SINGER_MESSAGES
+                             if isinstance(m, singer.RecordMessage)]
+
+        self.assertEqual(record_messages_2,
+                         [['table_3', {'id': "chicken-2", 'bar': 'def', 'foo': 200}],
+                          ['table_3', {'id': "turkey",    'bar': 'abc', 'foo': 100}],
+                          ['table_1', {'id': 1,           'bar': 'abc', 'foo': 100}],
+                          ['table_1', {'id': 2,           'bar': 'def', 'foo': 200}],
+                          ['table_1', {'id': 3,           'bar': 'ghi', 'foo': 300}]])
+
+        self.assertIsNone(state['currently_syncing'])
+
+        table_1_bookmark = state['bookmarks']['tap_mysql_test-table_1']
+        table_3_bookmark = state['bookmarks']['tap_mysql_test-table_3']
+
+        self.assertEqual(table_1_bookmark,
+                         {'initial_full_table_complete': True})
+
+        self.assertIsNone(table_3_bookmark.get('initial_full_table_complete'))
+
+        table_3_version = table_3_bookmark['version']
+        self.assertIsNotNone(table_3_version)
+
+        self.assertIsNone(table_3_bookmark.get('max_pk_values'))
+        self.assertIsNone(table_3_bookmark.get('last_pk_fetched'))
+
+        self.assertIsNotNone(table_3_bookmark.get('log_file'))
+        self.assertIsNotNone(table_3_bookmark.get('log_pos'))
+
+
+        new_table_3_records = [[ "quail-2", 400, 'jkl' ],
+                               [ "quail-100", 500, 'mno' ]]
+
+        for record in new_table_3_records:
+            insert_record_with_specific_id(self.conn, 'table_3', record)
+
+        TABLE_3_RECORD_COUNT = 0
+        SINGER_MESSAGES.clear()
+
+        tap_mysql.do_sync(self.conn, config, self.catalog, state)
+
+        self.assertFalse(failed_syncing_table_3)
+
+        record_messages_3 = [[m.stream, m.record] for m in SINGER_MESSAGES
+                             if isinstance(m, singer.RecordMessage)]
+
+        # Now that we are performing binlog sync, record output should be based on insert order
+        self.assertEqual(record_messages_3,
+                         [['table_1', {'id': 1,           'bar': 'abc', 'foo': 100}],
+                          ['table_1', {'id': 2,           'bar': 'def', 'foo': 200}],
+                          ['table_1', {'id': 3,           'bar': 'ghi', 'foo': 300}],
+                          ['table_3', {'id': "quail-2"  , 'bar': 'jkl', 'foo': 400}],
+                          ['table_3', {'id': "quail-100", 'bar': 'mno', 'foo': 500}]])
+
+        self.assertIsNone(state['currently_syncing'])
+
+        table_1_bookmark = state['bookmarks']['tap_mysql_test-table_1']
+        table_3_bookmark = state['bookmarks']['tap_mysql_test-table_3']
+
+        self.assertEqual(table_1_bookmark,
+                         {'initial_full_table_complete': True})
+
+        self.assertIsNone(table_3_bookmark.get('initial_full_table_complete'))
+        self.assertIsNotNone(table_3_bookmark.get('log_file'))
+        self.assertIsNotNone(table_3_bookmark.get('log_pos'))
 
 class FullTableInterruption(unittest.TestCase):
     def setUp(self):
@@ -329,4 +515,4 @@ class FullTableInterruption(unittest.TestCase):
 if __name__== "__main__":
     test1 = BinlogInterruption()
     test1.setUp()
-    test1.test_table_2_interrupted()
+    test1.test_table_3_interrupted()

--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -448,6 +448,17 @@ class FullTableInterruption(unittest.TestCase):
         state = {}
         failed_syncing_table_2 = False
 
+        # Do not worry about table_3
+        for stream in filter(lambda s: s.stream == 'table_3', self.catalog.streams):
+            md_map = singer.metadata.to_map(stream.metadata)
+            md_map = singer.metadata.write(md_map,
+                                    (),
+                                    'selected',
+                                    False)
+
+            stream.metadata = singer.metadata.to_list(md_map)
+
+
         try:
             tap_mysql.do_sync(self.conn, {}, self.catalog, state)
         except Exception as ex:


### PR DESCRIPTION
If the config enables the boolean flag `allow_non_auto_increment_pks`, override the prior restriction that PKs needed to be auto-incrementing to allow the initial full table sync for binlog replication to span multiple runs.