### PR TITLE
make resumable full table sync more widely available (remove allow_non_auto_increment_pks)

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -553,7 +553,7 @@ def do_sync_historical_binlog(mysql_conn, config, catalog_entry, state, columns)
 
     if log_file and log_pos and max_pk_values:
         LOGGER.info("Resuming initial full table sync for LOG_BASED stream %s", catalog_entry.tap_stream_id)
-        full_table.sync_table(mysql_conn, config, catalog_entry, state, columns, stream_version)
+        full_table.sync_table(mysql_conn, catalog_entry, state, columns, stream_version)
 
     else:
         LOGGER.info("Performing initial full table sync for LOG_BASED stream %s", catalog_entry.tap_stream_id)
@@ -569,10 +569,9 @@ def do_sync_historical_binlog(mysql_conn, config, catalog_entry, state, columns)
                                       'version',
                                       stream_version)
 
-        if (full_table.pks_are_auto_incrementing(mysql_conn, catalog_entry) or
-          full_table.pks_are_integer_or_varchar(mysql_conn, config, catalog_entry)):
-            # We must save log_file and log_pos across FULL_TABLE syncs when using
-            # an incrementing PK
+        if full_table.sync_is_resumable(mysql_conn, catalog_entry):
+            # We must save log_file and log_pos across FULL_TABLE syncs when performing
+            # a resumable full table sync
             state = singer.write_bookmark(state,
                                           catalog_entry.tap_stream_id,
                                           'log_file',
@@ -583,10 +582,9 @@ def do_sync_historical_binlog(mysql_conn, config, catalog_entry, state, columns)
                                           'log_pos',
                                           current_log_pos)
 
-            full_table.sync_table(mysql_conn, config, catalog_entry, state, columns, stream_version)
-
+            full_table.sync_table(mysql_conn, catalog_entry, state, columns, stream_version)
         else:
-            full_table.sync_table(mysql_conn, config, catalog_entry, state, columns, stream_version)
+            full_table.sync_table(mysql_conn, catalog_entry, state, columns, stream_version)
             state = singer.write_bookmark(state,
                                           catalog_entry.tap_stream_id,
                                           'log_file',
@@ -606,7 +604,7 @@ def do_sync_full_table(mysql_conn, config, catalog_entry, state, columns):
 
     stream_version = common.get_stream_version(catalog_entry.tap_stream_id, state)
 
-    full_table.sync_table(mysql_conn, config, catalog_entry, state, columns, stream_version)
+    full_table.sync_table(mysql_conn, catalog_entry, state, columns, stream_version)
 
     # Prefer initial_full_table_complete going forward
     singer.clear_bookmark(state, catalog_entry.tap_stream_id, 'version')

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -67,8 +67,8 @@ def verify_binlog_config(mysql_conn):
             except pymysql.err.InternalError as ex:
                 if ex.args[0] == 1193:
                     raise Exception("Unable to replicate binlog stream because binlog_row_image system variable does not exist. MySQL version must be at least 5.6.2 to use binlog replication.")
-                else:
-                    raise ex
+
+                raise ex
 
             if binlog_row_image != 'FULL':
                 raise Exception("Unable to replicate binlog stream because binlog_row_image is not set to 'FULL': {}."

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -28,19 +28,30 @@ def generate_bookmark_keys(catalog_entry):
     return bookmark_keys
 
 
-def pks_are_auto_incrementing(mysql_conn, catalog_entry):
+RESUMABLE_PK_TYPES = set([
+    'tinyint',
+    'smallint'
+    'mediumint',
+    'int',
+    'bigint',
+    'char',
+    'varchar',
+])
+
+def sync_is_resumable(mysql_conn, catalog_entry):
+    ''' In order to resume a full table sync, a table requires
+    '''
     database_name = common.get_database_name(catalog_entry)
     key_properties = common.get_key_properties(catalog_entry)
 
     if not key_properties:
         return False
 
-    sql = """SELECT 1
+    sql = """SELECT data_type
                FROM information_schema.columns
               WHERE table_schema = '{}'
                 AND table_name = '{}'
                 AND column_name = '{}'
-                AND extra LIKE '%auto_increment%'
     """
 
     with connect_with_backoff(mysql_conn) as open_conn:
@@ -53,53 +64,12 @@ def pks_are_auto_incrementing(mysql_conn, catalog_entry):
                 result = cur.fetchone()
 
                 if not result:
+                    raise Exception("Primary key column {} does not exist.".format(pk))
+
+                if result[0] not in RESUMABLE_PK_TYPES:
                     return False
 
     return True
-
-
-def pks_are_integer_or_varchar(mysql_conn, config, catalog_entry):
-    database_name = common.get_database_name(catalog_entry)
-    key_properties = common.get_key_properties(catalog_entry)
-
-    if config.get('allow_non_auto_increment_pks') == 'true' and key_properties:
-        valid_column_types = set([
-            'tinyint',
-            'smallint'
-            'mediumint',
-            'int',
-            'bigint',
-            'varchar',
-            'char'
-        ])
-
-
-        sql = """SELECT data_type
-                   FROM information_schema.columns
-                  WHERE table_schema = '{}'
-                    AND table_name = '{}'
-                    AND column_name = '{}'
-        """
-
-        with connect_with_backoff(mysql_conn) as open_conn:
-            with open_conn.cursor() as cur:
-                for pk in key_properties:
-                    cur.execute(sql.format(database_name,
-                                              catalog_entry.table,
-                                              pk))
-
-                    result = cur.fetchone()
-
-                    if not result:
-                        raise Exception("Primary key column {} does not exist.".format(pk))
-
-                    if result[0] not in valid_column_types:
-                        return False
-
-        return True
-
-    return False
-
 
 
 def get_max_pk_values(cursor, catalog_entry):
@@ -201,7 +171,7 @@ def update_incremental_full_table_state(catalog_entry, state, cursor):
 
     return state
 
-def sync_table(mysql_conn, config, catalog_entry, state, columns, stream_version):
+def sync_table(mysql_conn, catalog_entry, state, columns, stream_version):
     common.whitelist_bookmark_keys(generate_bookmark_keys(catalog_entry), catalog_entry.tap_stream_id, state)
 
     bookmark = state.get('bookmarks', {}).get(catalog_entry.tap_stream_id, {})
@@ -225,24 +195,16 @@ def sync_table(mysql_conn, config, catalog_entry, state, columns, stream_version
     if not initial_full_table_complete and not (version_exists and state_version is None):
         singer.write_message(activate_version_message)
 
-    key_props_are_auto_incrementing = pks_are_auto_incrementing(mysql_conn, catalog_entry)
+    perform_resumable_sync = sync_is_resumable(mysql_conn, catalog_entry)
 
-    allow_non_auto_incrementing_pk = pks_are_integer_or_varchar(mysql_conn,
-                                                                      config,
-                                                                      catalog_entry)
     pk_clause = ""
 
     with connect_with_backoff(mysql_conn) as open_conn:
         with open_conn.cursor() as cur:
             select_sql = common.generate_select_sql(catalog_entry, columns)
 
-            if key_props_are_auto_incrementing:
-                LOGGER.info("Detected auto-incrementing primary key(s) - will replicate incrementally")
-
-                state = update_incremental_full_table_state(catalog_entry, state, cur)
-                pk_clause = generate_pk_clause(catalog_entry, state)
-            elif allow_non_auto_incrementing_pk:
-                LOGGER.info("Allowing non-auto-incrementing primary key(s) - will replicate incrementally")
+            if perform_resumable_sync:
+                LOGGER.info("Full table sync is resumable based on primary key definition, will replicate incrementally")
 
                 state = update_incremental_full_table_state(catalog_entry, state, cur)
                 pk_clause = generate_pk_clause(catalog_entry, state)
@@ -250,7 +212,6 @@ def sync_table(mysql_conn, config, catalog_entry, state, columns, stream_version
             select_sql += pk_clause
             params = {}
 
-            # common.sync_query(cur, catalog_entry, state, select_sql, columns, stream_version, params)
             common.sync_query(cur,
                               catalog_entry,
                               state,

--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -308,7 +308,6 @@ class BinlogInterruption(unittest.TestCase):
             stream.metadata = singer.metadata.to_list(md_map)
 
         config = test_utils.get_db_config()
-        config['allow_non_auto_increment_pks'] = 'true'
 
         try:
             tap_mysql.do_sync(self.conn, config, self.catalog, state)


### PR DESCRIPTION
Prior to this change, resumable full table syncs required an auto-incrementing primary key. The `allow_non_auto_increment_pks` config property could be set to bypass the need for an auto-incrementing PK by specifying a set of valid primary key data types. The tap will no longer check for an auto-incrementing primary key. Instead, the `allow_non_auto_increment_pks` logic has been made the default without the need for the config property.