### PR TITLE
Properly support date and time type incremental bookmarks

### DIFF
--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -102,6 +102,9 @@ def to_utc_datetime_str(val):
         epoch = datetime.datetime.utcfromtimestamp(0)
         the_datetime = epoch + val
 
+    else:
+        raise ValueError("{!r} is not a valid date or time type".format(val))
+
     if the_datetime.tzinfo == None:
         # The mysql-replication library creates naive date and datetime objects
         # which will use the local timezone thus we must set tzinfo accordingly


### PR DESCRIPTION
Motivation
----------

https://stitchdata.atlassian.net/browse/SRCE-722

We added support for date and time type incremental bookmarks for the
full table syncs in dc4a0e0 and following. Unfortunately, we couldn't
write these types as bookmarks because they were not formatted as strings.

This change stores them as strings when they're generated and then
everywhere else can just use them as is.