### PR TITLE
get max values for pks instead of triple sorting

### DIFF
--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -92,17 +92,13 @@ def get_max_pk_values(cursor, catalog_entry):
 
     sql = """SELECT {}
                FROM {}.{}
-              ORDER BY {}
-              LIMIT 1
     """
 
-    select_column_clause = ", ".join(escaped_columns)
-    order_column_clause = ", ".join([pk + " DESC" for pk in escaped_columns])
+    select_column_clause = ", ".join(["max(" + pk + ")" for pk in escaped_columns])
 
     cursor.execute(sql.format(select_column_clause,
                            escaped_db,
-                           escaped_table,
-                           order_column_clause))
+                           escaped_table))
     result = cursor.fetchone()
     processed_results = []
     for bm in result:

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -107,9 +107,9 @@ def get_max_pk_values(cursor, catalog_entry):
         elif bm:
             processed_results += [bm]
 
+    max_pk_values = {}
     if processed_results:
         max_pk_values = dict(zip(key_properties, processed_results))
-
 
     return max_pk_values
 

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -102,10 +102,7 @@ def get_max_pk_values(cursor, catalog_entry):
     result = cursor.fetchone()
     processed_results = []
     for bm in result:
-        if isinstance(
-                bm, datetime.date) or isinstance(
-                    bm, datetime.datetime) or isinstance(
-                        bm, datetime.timedelta):
+        if isinstance(bm, (datetime.date, datetime.datetime, datetime.timedelta)):
             processed_results += [common.to_utc_datetime_str(bm)]
         else:
             processed_results += [bm]

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -110,6 +110,7 @@ def get_max_pk_values(cursor, catalog_entry):
     if processed_results:
         max_pk_values = dict(zip(key_properties, processed_results))
 
+    LOGGER.info(max_pk_values)
     return max_pk_values
 
 def generate_pk_clause(catalog_entry, state):

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -100,21 +100,17 @@ def get_max_pk_values(cursor, catalog_entry):
                            escaped_db,
                            escaped_table))
     result = cursor.fetchone()
-    LOGGER.info('Result: ' + str(result))
     processed_results = []
     for bm in result:
         if isinstance(bm, (datetime.date, datetime.datetime, datetime.timedelta)):
             processed_results += [common.to_utc_datetime_str(bm)]
-        else:
+        elif bm:
             processed_results += [bm]
 
-    LOGGER.info('Processed Results: ' + str(processed_results))
-    LOGGER.info('Length: ' + len(processed_results))
     if processed_results:
         max_pk_values = dict(zip(key_properties, processed_results))
 
 
-    LOGGER.info('Max PK values: ' + str(max_pk_values))
     return max_pk_values
 
 def generate_pk_clause(catalog_entry, state):

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -100,6 +100,7 @@ def get_max_pk_values(cursor, catalog_entry):
                            escaped_db,
                            escaped_table))
     result = cursor.fetchone()
+    LOGGER.info('Result: ' + str(result))
     processed_results = []
     for bm in result:
         if isinstance(bm, (datetime.date, datetime.datetime, datetime.timedelta)):
@@ -110,7 +111,7 @@ def get_max_pk_values(cursor, catalog_entry):
     if processed_results:
         max_pk_values = dict(zip(key_properties, processed_results))
 
-    LOGGER.info(max_pk_values)
+    LOGGER.info('Max PK values: ' + str(max_pk_values))
     return max_pk_values
 
 def generate_pk_clause(catalog_entry, state):

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -109,7 +109,7 @@ def get_max_pk_values(cursor, catalog_entry):
             processed_results += [bm]
 
     LOGGER.info('Processed Results: ' + str(processed_results))
-    LOGGER.info('Count: ' + len(processed_results))
+    LOGGER.info('Length: ' + len(processed_results))
     if processed_results:
         max_pk_values = dict(zip(key_properties, processed_results))
 

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -113,7 +113,7 @@ def get_max_pk_values(cursor, catalog_entry):
     if processed_results:
         max_pk_values = dict(zip(key_properties, processed_results))
 
-    
+
     LOGGER.info('Max PK values: ' + str(max_pk_values))
     return max_pk_values
 

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -108,9 +108,12 @@ def get_max_pk_values(cursor, catalog_entry):
         else:
             processed_results += [bm]
 
+    LOGGER.info('Processed Results: ' + str(processed_results))
+    LOGGER.info('Count: ' + len(processed_results))
     if processed_results:
         max_pk_values = dict(zip(key_properties, processed_results))
 
+    
     LOGGER.info('Max PK values: ' + str(max_pk_values))
     return max_pk_values
 


### PR DESCRIPTION
Previously, we were grabbing the max values for each primary key via this type of query:
```
select <pk_values> from <table> order by <pk_1> desc, <pk_2> desc, ...., <pk_n> desc, limit 1
```
This approach is error-prone since there is no guarantee that a single row exists with all PKs at their max.  

Instead, use the following query:
```
select max(<pk_1>), max(<pk_2>), ... , max(<pk_n>) from <table>;
```