### PR TITLE
Fix a KeyError in generate_pk_clause

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='tap-mysql',
       install_requires=[
           'attrs==16.3.0',
           'pendulum==1.2.0',
-          'singer-python==5.3.1',
+          'singer-python==5.5.0',
           'PyMySQL==0.7.11',
           'backoff==1.3.2',
           'mysql-replication==0.18',

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -703,8 +703,8 @@ def log_server_params(mysql_conn):
         except pymysql.err.InternalError as e:
             LOGGER.warning("Encountered error checking server params. Error: (%s) %s", *e.args)
 
-
-def main_impl():
+@utils.handle_top_exception(LOGGER)
+def main():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
 
     mysql_conn = MySQLConnection(args.config)
@@ -722,10 +722,5 @@ def main_impl():
     else:
         LOGGER.info("No properties were selected")
 
-
-def main():
-    try:
-        main_impl()
-    except Exception as exc:
-        LOGGER.critical(exc)
-        raise exc
+if __name__ == "__main__":
+    main()

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -104,7 +104,7 @@ def get_max_pk_values(cursor, catalog_entry):
     for bm in result:
         if isinstance(bm, (datetime.date, datetime.datetime, datetime.timedelta)):
             processed_results += [common.to_utc_datetime_str(bm)]
-        elif bm:
+        elif bm is not None:
             processed_results += [bm]
 
     max_pk_values = {}


### PR DESCRIPTION
This PR makes 2 changes:
1. It changes the way the `get_max_pk_values()` function processes max values from the table we are syncing. There was an issue where the max of a primary key comes back as `0`, and when we go to decide if we should include it in the `processed_results` by doing `elif bm:`, the `0` is falsy. This effectively leads to a truncated dictionary, which leads to a key error when we ask for a key that we expect to be there.

2. It changes the top level error handling to use the `singer` error decorator.