### PR TITLE
include the _sdc_deleted_at field for all binlog records

### DIFF
--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -226,7 +226,9 @@ def handle_write_rows_event(event, catalog_entry, state, columns, rows_saved, ti
     db_column_types = get_db_column_types(event)
 
     for row in event.rows:
-        filtered_vals = {k:v for k,v in row['values'].items()
+        vals = row['values']
+        vals[SDC_DELETED_AT] = None
+        filtered_vals = {k:v for k,v in vals.items()
                          if k in columns}
 
         record_message = row_to_singer_record(catalog_entry,
@@ -246,7 +248,9 @@ def handle_update_rows_event(event, catalog_entry, state, columns, rows_saved, t
     db_column_types = get_db_column_types(event)
 
     for row in event.rows:
-        filtered_vals = {k:v for k,v in row['after_values'].items()
+        vals = row['after_values']
+        vals[SDC_DELETED_AT] = None
+        filtered_vals = {k:v for k,v in vals.items()
                          if k in columns}
 
         record_message = row_to_singer_record(catalog_entry,

--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -276,8 +276,8 @@ class BinlogInterruption(unittest.TestCase):
                          [['table_1', {'id': 1, 'bar': 'abc', 'foo': 100}],
                           ['table_1', {'id': 2, 'bar': 'def', 'foo': 200}],
                           ['table_1', {'id': 3, 'bar': 'ghi', 'foo': 300}],
-                          ['table_2', {'id': 4, 'bar': 'jkl', 'foo': 400}],
-                          ['table_2', {'id': 5, 'bar': 'mno', 'foo': 500}]])
+                          ['table_2', {'_sdc_deleted_at': None, 'id': 4, 'bar': 'jkl', 'foo': 400}],
+                          ['table_2', {'_sdc_deleted_at': None, 'id': 5, 'bar': 'mno', 'foo': 500}]])
 
         self.assertIsNone(state['currently_syncing'])
 
@@ -408,8 +408,8 @@ class BinlogInterruption(unittest.TestCase):
                          [['table_1', {'id': 1,           'bar': 'abc', 'foo': 100}],
                           ['table_1', {'id': 2,           'bar': 'def', 'foo': 200}],
                           ['table_1', {'id': 3,           'bar': 'ghi', 'foo': 300}],
-                          ['table_3', {'id': "quail-2"  , 'bar': 'jkl', 'foo': 400}],
-                          ['table_3', {'id': "quail-100", 'bar': 'mno', 'foo': 500}]])
+                          ['table_3', {'_sdc_deleted_at': None, 'id': "quail-2"  , 'bar': 'jkl', 'foo': 400}],
+                          ['table_3', {'_sdc_deleted_at': None, 'id': "quail-100", 'bar': 'mno', 'foo': 500}]])
 
         self.assertIsNone(state['currently_syncing'])
 


### PR DESCRIPTION
Done to make the data emitted by the tap more "rectangular", and for consistency with tap-postgres