### PR TITLE
Implement SSH Tunneling

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,24 @@ Create a config file containing the database connection credentials, e.g.:
 These are the same basic configuration properties used by the MySQL command-line
 client (`mysql`).
 
+#### Connecting over an SSH Tunnel
+
+To connect to your database over an SSH tunnel add the following params to your config.
+
+```json
+{
+  "host": "localhost",
+  "port": "3306",
+  "user": "root",
+  "password": "password",
+  "ssh_host": "localhost",
+  "ssh_port": 22,
+  "ssh_username": "user",
+  "ssh_pkey": "/path/to/private_key"
+}
+
+```
+
 ### Discovery mode
 
 The tap can be invoked in discovery mode to find the available tables and

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-mysql',
-      version='1.15.0',
+      version='1.16.0',
       description='Singer.io tap for extracting data from MySQL',
       author='Stitch',
       url='https://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(name='tap-mysql',
           'PyMySQL==0.7.11',
           'backoff==1.3.2',
           'mysql-replication==0.18',
+          'sshtunnel==0.1.5',
       ],
       entry_points='''
           [console_scripts]

--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -122,15 +122,16 @@ class MySQLConnection(pymysql.connections.Connection):
             }
 
         if config['ssh_host']:
-            tunnel = SSHTunnelForwarder((config['ssh_host'], config['ssh_port'
-                                    ]), ssh_username=config['ssh_username'
-                                    ], ssh_pkey=config['ssh_pkey'],
-                                    remote_bind_address=(config['host'],
-                                    config['port']))
+            tunnel = SSHTunnelForwarder(
+                (config['ssh_host'], config['ssh_port']), 
+                ssh_username=config['ssh_username'], 
+                ssh_pkey=config['ssh_pkey'],
+                remote_bind_address=(config['host'],config['port'])
+            )
 
             tunnel.start()
 
-            args['host'] = tunnel.local_bind_host
+            args['host'] = '127.0.0.1'
             args['port'] = tunnel.local_bind_port
 
             ssl_arg = None

--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import backoff
 
@@ -17,6 +18,7 @@ CONNECT_TIMEOUT_SECONDS = 30
 READ_TIMEOUT_SECONDS = 3600
 
 # We need to hold onto this for self-signed SSL
+
 match_hostname = ssl.match_hostname
 
 # MySQL 8.0 Patch:
@@ -25,19 +27,23 @@ match_hostname = ssl.match_hostname
 # new character sets to be used with MySQL 8.0 instances.
 # FIXME: Remove when PyMYSQL upgrade behavior has been evaluated.
 # Patch Originally Found Here: https://github.com/PyMySQL/PyMySQL/pull/592
+
 original_charset_by_id = pymysql.charset.charset_by_id
+
+
 def charset_wrapper(*args, **kwargs):
     unknown_charset = pymysql.charset.Charset(None, None, None, None)
     try:
         return original_charset_by_id(*args, **kwargs)
     except KeyError:
         return unknown_charset
+
+
 pymysql.connections.charset_by_id = charset_wrapper
 
-@backoff.on_exception(backoff.expo,
-                      (pymysql.err.OperationalError),
-                      max_tries=5,
-                      factor=2)
+
+@backoff.on_exception(backoff.expo, pymysql.err.OperationalError,
+                      max_tries=5, factor=2)
 def connect_with_backoff(connection):
     connection.connect()
 
@@ -51,24 +57,21 @@ def connect_with_backoff(connection):
         try:
             cur.execute('SET @@session.wait_timeout=2700')
         except pymysql.err.InternalError as e:
-             warnings.append('Could not set session.wait_timeout. Error: ({}) {}'.format(*e.args))
+            warnings.append('Could not set session.wait_timeout. Error: ({}) {}'.format(*e.args))
 
         try:
-            cur.execute("SET @@session.net_read_timeout={}".format(READ_TIMEOUT_SECONDS))
+            cur.execute('SET @@session.net_read_timeout={}'.format(READ_TIMEOUT_SECONDS))
         except pymysql.err.InternalError as e:
-             warnings.append('Could not set session.net_read_timeout. Error: ({}) {}'.format(*e.args))
-
+            warnings.append('Could not set session.net_read_timeout. Error: ({}) {}'.format(*e.args))
 
         try:
             cur.execute('SET @@session.innodb_lock_wait_timeout=2700')
         except pymysql.err.InternalError as e:
-            warnings.append(
-                'Could not set session.innodb_lock_wait_timeout. Error: ({}) {}'.format(*e.args)
-                )
+            warnings.append('Could not set session.innodb_lock_wait_timeout. Error: ({}) {}'.format(*e.args))
 
         if warnings:
-            LOGGER.info(("Encountered non-fatal errors when configuring MySQL session that could "
-                         "impact performance:"))
+            LOGGER.info('Encountered non-fatal errors when configuring MySQL session that could impact performance:'
+                        )
         for w in warnings:
             LOGGER.warning(w)
 
@@ -76,18 +79,22 @@ def connect_with_backoff(connection):
 
 
 def parse_internal_hostname(hostname):
+
     # special handling for google cloud
-    if ":" in hostname:
-        parts = hostname.split(":")
+
+    if ':' in hostname:
+        parts = hostname.split(':')
         if len(parts) == 3:
-            return parts[0] + ":" + parts[2]
-        return parts[0] + ":" + parts[1]
+            return parts[0] + ':' + parts[2]
+        return parts[0] + ':' + parts[1]
 
     return hostname
 
 
 class MySQLConnection(pymysql.connections.Connection):
+
     def __init__(self, config):
+
         # Google Cloud's SSL involves a self-signed certificate. This certificate's
         # hostname matches the form {instance}:{box}. The hostname displayed in the
         # Google Cloud UI is of the form {instance}:{region}:{box} which
@@ -103,77 +110,148 @@ class MySQLConnection(pymysql.connections.Connection):
         # patched out method to it's original spot.
 
         args = {
-            "user": config["user"],
-            "password": config["password"],
-            "host": config["host"],
-            "port": int(config["port"]),
-            "cursorclass": config.get("cursorclass") or pymysql.cursors.SSCursor,
-            "connect_timeout": CONNECT_TIMEOUT_SECONDS,
-            "read_timeout": READ_TIMEOUT_SECONDS,
-            "charset": "utf8",
-        }
+            'user': config['user'],
+            'password': config['password'],
+            'host': config['host'],
+            'port': int(config['port']),
+            'cursorclass': config.get('cursorclass') \
+                or pymysql.cursors.SSCursor,
+            'connect_timeout': CONNECT_TIMEOUT_SECONDS,
+            'read_timeout': READ_TIMEOUT_SECONDS,
+            'charset': 'utf8',
+            }
 
-        with SSHTunnelForwarder(
-            (config["ssh_host"], config["ssh_port"]),
-            ssh_username=config["ssh_username"],
-            ssh_pkey=config["ssh_pkey"],
-            remote_bind_address=(args["host"], args["port"])
-        ) as tunnel:
+        if(config['ssh_host']):
+            with SSHTunnelForwarder((config['ssh_host'], config['ssh_port'
+                                    ]), ssh_username=config['ssh_username'
+                                    ], ssh_pkey=config['ssh_pkey'],
+                                    remote_bind_address=(config['host'],
+                                    config['port'])) as tunnel:
+                args['host'] = '127.0.0.1'
+                args['port'] = tunnel.local_bind_port
 
-            args["host"] = tunnel.local_bind_host
-            args["port"] = tunnel.local_bind_port
+                ssl_arg = None
 
+                if config.get('database'):
+                    args['database'] = config['database']
+
+                use_ssl = config.get('ssl') == 'true'
+
+                # Attempt self-signed SSL if config vars are present
+
+                use_self_signed_ssl = config.get('ssl_ca')
+
+                if use_ssl and use_self_signed_ssl:
+                    LOGGER.info('Using custom certificate authority')
+
+                    # Config values MUST be paths to files for the SSL module to read them correctly.
+
+                    ssl_arg = {'ca': config['ssl_ca'],
+                               'check_hostname': config.get('check_hostname'
+                               , 'true') == 'true'}
+
+                    # If using client authentication, cert and key are required
+
+                    if config.get('ssl_cert') and config.get('ssl_key'):
+                        ssl_arg['cert'] = config['ssl_cert']
+                        ssl_arg['key'] = config['ssl_key']
+
+                    # override match hostname for google cloud
+
+                    if config.get('internal_hostname'):
+                        parsed_hostname = \
+                            parse_internal_hostname(config['internal_hostname'
+                                ])
+                        ssl.match_hostname = lambda cert, hostname: \
+                            match_hostname(cert, parsed_hostname)
+
+                super().__init__(defer_connect=True, ssl=ssl_arg, **args)
+
+                # Configure SSL without custom CA
+                # Manually create context to override default behavior of
+                # CERT_NONE without a CA supplied
+
+                if use_ssl and not use_self_signed_ssl:
+                    LOGGER.info('Attempting SSL connection')
+
+                    # For compatibility with previous version, verify mode is off by default
+
+                    verify_mode = config.get('verify_mode', 'false') \
+                        == 'true'
+                    if not verify_mode:
+                        LOGGER.warn("Not verifying server certificate. The connection is encrypted, but the server hasn't been verified. Please provide a root CA certificate to enable verification."
+                                    )
+                    self.ssl = True
+                    self.ctx = ssl.create_default_context()
+                    check_hostname = config.get('check_hostname', 'false') \
+                        == 'true'
+                    self.ctx.check_hostname = check_hostname
+                    self.ctx.verify_mode = \
+                        (ssl.CERT_REQUIRED if verify_mode else ssl.CERT_NONE)
+                    self.client_flag |= CLIENT.SSL
+        else:
             ssl_arg = None
 
-            if config.get("database"):
-                args["database"] = config["database"]
+            if config.get('database'):
+                args['database'] = config['database']
 
             use_ssl = config.get('ssl') == 'true'
 
             # Attempt self-signed SSL if config vars are present
-            use_self_signed_ssl = config.get("ssl_ca")
+
+            use_self_signed_ssl = config.get('ssl_ca')
 
             if use_ssl and use_self_signed_ssl:
-                LOGGER.info("Using custom certificate authority")
+                LOGGER.info('Using custom certificate authority')
 
                 # Config values MUST be paths to files for the SSL module to read them correctly.
-                ssl_arg = {
-                    "ca": config["ssl_ca"],
-                    "check_hostname": config.get("check_hostname", "true") == "true"
-                }
+
+                ssl_arg = {'ca': config['ssl_ca'],
+                           'check_hostname': config.get('check_hostname'
+                           , 'true') == 'true'}
 
                 # If using client authentication, cert and key are required
-                if config.get("ssl_cert") and config.get("ssl_key"):
-                    ssl_arg["cert"] = config["ssl_cert"]
-                    ssl_arg["key"] = config["ssl_key"]
+
+                if config.get('ssl_cert') and config.get('ssl_key'):
+                    ssl_arg['cert'] = config['ssl_cert']
+                    ssl_arg['key'] = config['ssl_key']
 
                 # override match hostname for google cloud
-                if config.get("internal_hostname"):
-                    parsed_hostname = parse_internal_hostname(config["internal_hostname"])
-                    ssl.match_hostname = lambda cert, hostname: match_hostname(cert, parsed_hostname)
+
+                if config.get('internal_hostname'):
+                    parsed_hostname = \
+                        parse_internal_hostname(config['internal_hostname'
+                            ])
+                    ssl.match_hostname = lambda cert, hostname: \
+                        match_hostname(cert, parsed_hostname)
 
             super().__init__(defer_connect=True, ssl=ssl_arg, **args)
 
             # Configure SSL without custom CA
             # Manually create context to override default behavior of
             # CERT_NONE without a CA supplied
+
             if use_ssl and not use_self_signed_ssl:
-                LOGGER.info("Attempting SSL connection")
+                LOGGER.info('Attempting SSL connection')
+
                 # For compatibility with previous version, verify mode is off by default
-                verify_mode = config.get("verify_mode", "false") == 'true'
+
+                verify_mode = config.get('verify_mode', 'false') \
+                    == 'true'
                 if not verify_mode:
-                    LOGGER.warn("Not verifying server certificate. The connection is encrypted, but the server hasn't been verified. Please provide a root CA certificate to enable verification.")
+                    LOGGER.warn("Not verifying server certificate. The connection is encrypted, but the server hasn't been verified. Please provide a root CA certificate to enable verification."
+                                )
                 self.ssl = True
                 self.ctx = ssl.create_default_context()
-                check_hostname = config.get("check_hostname", "false") == 'true'
+                check_hostname = config.get('check_hostname', 'false') \
+                    == 'true'
                 self.ctx.check_hostname = check_hostname
-                self.ctx.verify_mode = ssl.CERT_REQUIRED if verify_mode else ssl.CERT_NONE
+                self.ctx.verify_mode = \
+                    (ssl.CERT_REQUIRED if verify_mode else ssl.CERT_NONE)
                 self.client_flag |= CLIENT.SSL
-
 
     def __enter__(self):
         return self
-
 
     def __exit__(self, *exc_info):
         del exc_info
@@ -181,9 +259,11 @@ class MySQLConnection(pymysql.connections.Connection):
 
 
 def make_connection_wrapper(config):
+
     class ConnectionWrapper(MySQLConnection):
+
         def __init__(self, *args, **kwargs):
-            config["cursorclass"] = kwargs.get('cursorclass')
+            config['cursorclass'] = kwargs.get('cursorclass')
             super().__init__(config)
 
             connect_with_backoff(self)

--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -120,55 +120,55 @@ class MySQLConnection(pymysql.connections.Connection):
             remote_bind_address=(args["host"], args["port"])
         ) as tunnel:
 
-        args["host"] = tunnel.local_bind_host
-        args["port"] = tunnel.local_bind_port
+            args["host"] = tunnel.local_bind_host
+            args["port"] = tunnel.local_bind_port
 
-        ssl_arg = None
+            ssl_arg = None
 
-        if config.get("database"):
-            args["database"] = config["database"]
+            if config.get("database"):
+                args["database"] = config["database"]
 
-        use_ssl = config.get('ssl') == 'true'
+            use_ssl = config.get('ssl') == 'true'
 
-        # Attempt self-signed SSL if config vars are present
-        use_self_signed_ssl = config.get("ssl_ca")
+            # Attempt self-signed SSL if config vars are present
+            use_self_signed_ssl = config.get("ssl_ca")
 
-        if use_ssl and use_self_signed_ssl:
-            LOGGER.info("Using custom certificate authority")
+            if use_ssl and use_self_signed_ssl:
+                LOGGER.info("Using custom certificate authority")
 
-            # Config values MUST be paths to files for the SSL module to read them correctly.
-            ssl_arg = {
-                "ca": config["ssl_ca"],
-                "check_hostname": config.get("check_hostname", "true") == "true"
-            }
+                # Config values MUST be paths to files for the SSL module to read them correctly.
+                ssl_arg = {
+                    "ca": config["ssl_ca"],
+                    "check_hostname": config.get("check_hostname", "true") == "true"
+                }
 
-            # If using client authentication, cert and key are required
-            if config.get("ssl_cert") and config.get("ssl_key"):
-                ssl_arg["cert"] = config["ssl_cert"]
-                ssl_arg["key"] = config["ssl_key"]
+                # If using client authentication, cert and key are required
+                if config.get("ssl_cert") and config.get("ssl_key"):
+                    ssl_arg["cert"] = config["ssl_cert"]
+                    ssl_arg["key"] = config["ssl_key"]
 
-            # override match hostname for google cloud
-            if config.get("internal_hostname"):
-                parsed_hostname = parse_internal_hostname(config["internal_hostname"])
-                ssl.match_hostname = lambda cert, hostname: match_hostname(cert, parsed_hostname)
+                # override match hostname for google cloud
+                if config.get("internal_hostname"):
+                    parsed_hostname = parse_internal_hostname(config["internal_hostname"])
+                    ssl.match_hostname = lambda cert, hostname: match_hostname(cert, parsed_hostname)
 
-        super().__init__(defer_connect=True, ssl=ssl_arg, **args)
+            super().__init__(defer_connect=True, ssl=ssl_arg, **args)
 
-        # Configure SSL without custom CA
-        # Manually create context to override default behavior of
-        # CERT_NONE without a CA supplied
-        if use_ssl and not use_self_signed_ssl:
-            LOGGER.info("Attempting SSL connection")
-            # For compatibility with previous version, verify mode is off by default
-            verify_mode = config.get("verify_mode", "false") == 'true'
-            if not verify_mode:
-                LOGGER.warn("Not verifying server certificate. The connection is encrypted, but the server hasn't been verified. Please provide a root CA certificate to enable verification.")
-            self.ssl = True
-            self.ctx = ssl.create_default_context()
-            check_hostname = config.get("check_hostname", "false") == 'true'
-            self.ctx.check_hostname = check_hostname
-            self.ctx.verify_mode = ssl.CERT_REQUIRED if verify_mode else ssl.CERT_NONE
-            self.client_flag |= CLIENT.SSL
+            # Configure SSL without custom CA
+            # Manually create context to override default behavior of
+            # CERT_NONE without a CA supplied
+            if use_ssl and not use_self_signed_ssl:
+                LOGGER.info("Attempting SSL connection")
+                # For compatibility with previous version, verify mode is off by default
+                verify_mode = config.get("verify_mode", "false") == 'true'
+                if not verify_mode:
+                    LOGGER.warn("Not verifying server certificate. The connection is encrypted, but the server hasn't been verified. Please provide a root CA certificate to enable verification.")
+                self.ssl = True
+                self.ctx = ssl.create_default_context()
+                check_hostname = config.get("check_hostname", "false") == 'true'
+                self.ctx.check_hostname = check_hostname
+                self.ctx.verify_mode = ssl.CERT_REQUIRED if verify_mode else ssl.CERT_NONE
+                self.client_flag |= CLIENT.SSL
 
 
     def __enter__(self):

--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -5,8 +5,6 @@ import backoff
 
 import pymysql
 from pymysql.constants import CLIENT
-import paramiko
-from paramiko import SSHClient
 from sshtunnel import SSHTunnelForwarder
 
 import singer

--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -259,13 +259,6 @@ class MySQLConnection(pymysql.connections.Connection):
     def __exit__(self, *exc_info):
         del exc_info
 
-        try:
-            self.tunnel
-        except NameError:
-            #not defined
-        finally:
-            self.tunnel.close()
-
         self.close()
 
 

--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -4,6 +4,9 @@ import backoff
 
 import pymysql
 from pymysql.constants import CLIENT
+import paramiko
+from paramiko import SSHClient
+from sshtunnel import SSHTunnelForwarder
 
 import singer
 import ssl
@@ -109,6 +112,16 @@ class MySQLConnection(pymysql.connections.Connection):
             "read_timeout": READ_TIMEOUT_SECONDS,
             "charset": "utf8",
         }
+
+        with SSHTunnelForwarder(
+            (config["ssh_host"], config["ssh_port"]),
+            ssh_username=config["ssh_username"],
+            ssh_pkey=config["ssh_pkey"],
+            remote_bind_address=(args["host"], args["port"])
+        ) as tunnel:
+
+        args["host"] = tunnel.local_bind_host
+        args["port"] = tunnel.local_bind_port
 
         ssl_arg = None
 

--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -121,17 +121,17 @@ class MySQLConnection(pymysql.connections.Connection):
             }
 
         if config['ssh_host']:
-            tunnel = SSHTunnelForwarder(
+            self.tunnel = SSHTunnelForwarder(
                 (config['ssh_host'], config['ssh_port']), 
                 ssh_username=config['ssh_username'], 
                 ssh_pkey=config['ssh_pkey'],
                 remote_bind_address=(config['host'],config['port'])
             )
 
-            tunnel.start()
+            self.tunnel.start()
 
             args['host'] = '127.0.0.1'
-            args['port'] = tunnel.local_bind_port
+            args['port'] = self.tunnel.local_bind_port
 
             ssl_arg = None
 
@@ -258,9 +258,14 @@ class MySQLConnection(pymysql.connections.Connection):
 
     def __exit__(self, *exc_info):
         del exc_info
-        if(tunnel):
-            tunnel.stop()
-        
+
+        try:
+            self.tunnel
+        except NameError:
+            #not defined
+        else:
+            self.tunnel.close()
+
         self.close()
 
 

--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -258,6 +258,9 @@ class MySQLConnection(pymysql.connections.Connection):
 
     def __exit__(self, *exc_info):
         del exc_info
+        if(tunnel):
+            tunnel.stop()
+        
         self.close()
 
 

--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -263,7 +263,7 @@ class MySQLConnection(pymysql.connections.Connection):
             self.tunnel
         except NameError:
             #not defined
-        else:
+        finally:
             self.tunnel.close()
 
         self.close()

--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -5,6 +5,7 @@ import backoff
 
 import pymysql
 from pymysql.constants import CLIENT
+
 from sshtunnel import SSHTunnelForwarder
 
 import singer


### PR DESCRIPTION
This PR implements the option for SSH tunneling for the MySQL connection. It's incredibly useful for tapping databases hosted on platforms like AWS that are protected from public access. 

- The `README.md` has been updated with new configuration parameters.
- New dependencies have been added to `setup.py`
- Version has been bumped