### PR TITLE
Fix sorting of stream during full_table sync with composite PK

### DIFF
--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -117,8 +117,8 @@ def get_max_pk_values(cursor, catalog_entry):
 def quote_where_clause_value(value, column_type):
     if 'string' in column_type:
         return "'" + str(value) + "'"
-    else:
-        return str(value)
+
+    return str(value)
 
 
 def generate_pk_bookmark_clause(key_properties, last_pk_fetched, catalog_entry):

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -156,7 +156,6 @@ def generate_pk_bookmark_clause(key_properties, last_pk_fetched, catalog_entry):
 
 def generate_pk_clause(catalog_entry, state):
     key_properties = common.get_key_properties(catalog_entry)
-    escaped_columns = [common.escape(c) for c in key_properties]
 
     max_pk_values = singer.get_bookmark(state,
                                         catalog_entry.tap_stream_id,
@@ -194,9 +193,10 @@ def generate_pk_clause(catalog_entry, state):
 
             max_pk_comparisons.append("{} <= {}".format(common.escape(pk), pk_val))
 
+    order_by_columns = [common.escape(c) for c in key_properties]
     sql = " WHERE {}{} ORDER BY {} ASC".format(last_pk_clause,
                                                " AND ".join(max_pk_comparisons),
-                                               ", ".join(escaped_columns))
+                                               ", ".join(order_by_columns))
 
     return sql
 

--- a/tests/test_query_building.py
+++ b/tests/test_query_building.py
@@ -1,0 +1,58 @@
+import unittest
+import singer
+from singer import Schema
+from singer.catalog import CatalogEntry
+
+from tap_mysql.sync_strategies.full_table import generate_pk_bookmark_clause
+
+
+class TestFullTableWhereClause(unittest.TestCase):
+
+
+    def test_fails_with_null_bookmark(self):
+        catalog_entry = CatalogEntry(schema=Schema.from_dict({'properties':{}}))
+        key_properties = []
+        last_pk_fetched = None
+
+        with self.assertRaises(AssertionError):
+            generate_pk_bookmark_clause(key_properties, last_pk_fetched, catalog_entry)
+
+    def test_empty_pk(self):
+        catalog_entry = CatalogEntry(schema=Schema.from_dict({'properties':{}}))
+        key_properties = []
+        last_pk_fetched = {}
+
+        expected = ''
+        actual = generate_pk_bookmark_clause(key_properties, last_pk_fetched, catalog_entry)
+
+        self.assertEqual(expected, actual)
+
+    def test_one_pk(self):
+        catalog_entry = CatalogEntry(schema=Schema.from_dict({'properties':{'id1':{'type': ['integer']}}}))
+        key_properties = ['id1']
+        last_pk_fetched = {'id1': 4}
+
+        expected = '(`id1` > 4)'
+        actual = generate_pk_bookmark_clause(key_properties, last_pk_fetched, catalog_entry)
+
+        self.assertEqual(expected, actual)
+
+    def test_two_pks(self):
+        catalog_entry = CatalogEntry(schema=Schema.from_dict({'properties':{'id1':{'type': ['integer']}, 'str': {'type': ['string']}}}))
+        key_properties = ['id1', 'str']
+        last_pk_fetched = {'id1': 4, 'str': 'apples'}
+
+        expected = '(`id1` > 4) OR (`id1` = 4 AND `str` > \'apples\')'
+        actual = generate_pk_bookmark_clause(key_properties, last_pk_fetched, catalog_entry)
+
+        self.assertEqual(expected, actual)
+
+    def test_three_pks(self):
+        catalog_entry = CatalogEntry(schema=Schema.from_dict({'properties':{'id1':{'type': ['integer']}, 'str': {'type': ['string']}, 'number': {'type': ['number']}}}))
+        key_properties = ['id1', 'str', 'number']
+        last_pk_fetched = {'id1': 4, 'str': 'apples', 'number': 5.43}
+
+        expected = '(`id1` > 4) OR (`id1` = 4 AND `str` > \'apples\') OR (`id1` = 4 AND `str` = \'apples\' AND `number` > 5.43)'
+        actual = generate_pk_bookmark_clause(key_properties, last_pk_fetched, catalog_entry)
+
+        self.assertEqual(expected, actual)

--- a/tests/test_query_building.py
+++ b/tests/test_query_building.py
@@ -3,7 +3,7 @@ import singer
 from singer import Schema
 from singer.catalog import CatalogEntry
 
-from tap_mysql.sync_strategies.full_table import generate_pk_bookmark_clause
+from tap_mysql.sync_strategies.full_table import generate_pk_bookmark_clause, generate_pk_clause
 
 
 class TestFullTableWhereClause(unittest.TestCase):
@@ -56,3 +56,127 @@ class TestFullTableWhereClause(unittest.TestCase):
         actual = generate_pk_bookmark_clause(key_properties, last_pk_fetched, catalog_entry)
 
         self.assertEqual(expected, actual)
+
+class TestGeneratePkClause(unittest.TestCase):
+
+    def setUp(self):
+        self.maxDiff = None
+
+
+    def test_no_pk_values(self):
+        catalog_entry = CatalogEntry(schema=Schema.from_dict({'properties':{}}), metadata=[])
+        state = {}
+
+        expected = ''
+        actual = generate_pk_clause(catalog_entry, state)
+
+        self.assertEqual(expected, actual)
+
+    def test_one_pk_value_with_bookmark(self):
+        catalog_entry = CatalogEntry(tap_stream_id='foo',
+                                     schema=Schema.from_dict({
+                                         'properties':{
+                                             'id': {'type': ['integer']}
+                                         }
+                                     }),
+                                     metadata=[{'breadcrumb': (),
+                                                'metadata': {'table-key-properties': ['id']}}])
+        state = {
+            'bookmarks':
+                 {
+                     'foo': {
+                         'last_pk_fetched': {'id': 4},
+                         'max_pk_values': {'id':10}
+                     }
+                 }
+        }
+
+        expected = ' WHERE ((`id` > 4)) AND `id` <= 10 ORDER BY `id` ASC'
+        actual = generate_pk_clause(catalog_entry, state)
+
+        self.assertEqual(expected, actual)
+
+    def test_three_pk_values_with_bookmark(self):
+        catalog_entry = CatalogEntry(tap_stream_id='foo',
+                                     schema=Schema.from_dict({
+                                         'properties':{
+                                             'id1': {'type': ['integer']},
+                                             'id2': {'type': ['string']},
+                                             'id3': {'type': ['integer']}
+                                         }
+                                     }),
+                                     metadata=[{'breadcrumb': (),
+                                                'metadata': {'table-key-properties': ['id1', 'id2', 'id3']}}])
+        state = {
+            'bookmarks':
+                 {
+                     'foo': {
+                         'last_pk_fetched': {'id1': 4, 'id2': 6, 'id3': 2 },
+                         'max_pk_values': {'id1': 10, 'id2': 8, 'id3': 3}
+                     }
+                 }
+        }
+
+        expected = ' WHERE ((`id1` > 4) OR (`id1` = 4 AND `id2` > \'6\') OR (`id1` = 4 AND `id2` = \'6\' AND `id3` > 2)) AND `id1` <= 10 AND `id2` <= \'8\' AND `id3` <= 3 ORDER BY `id1`, `id2`, `id3` ASC'
+        actual = generate_pk_clause(catalog_entry, state)
+
+        self.assertEqual(expected, actual)
+
+    def test_one_pk_values_without_bookmark(self):
+        catalog_entry = CatalogEntry(tap_stream_id='foo',
+                                     schema=Schema.from_dict({
+                                         'properties':{
+                                             'id': {'type': ['integer']}
+                                         }
+                                     }),
+                                     metadata=[{'breadcrumb': (),
+                                                'metadata': {'table-key-properties': ['id']}}])
+        state = {
+            'bookmarks':
+                 {
+                     'foo': {
+                         'max_pk_values': {'id':10}
+                     }
+                 }
+        }
+
+        expected = ' WHERE `id` <= 10 ORDER BY `id` ASC'
+        actual = generate_pk_clause(catalog_entry, state)
+
+        self.assertEqual(expected, actual)
+
+    def test_three_pk_values_without_bookmark(self):
+        catalog_entry = CatalogEntry(tap_stream_id='foo',
+                                     schema=Schema.from_dict({
+                                         'properties':{
+                                             'id1': {'type': ['integer']},
+                                             'id2': {'type': ['string']},
+                                             'id3': {'type': ['integer']}
+                                         }
+                                     }),
+                                     metadata=[{'breadcrumb': (),
+                                                'metadata': {'table-key-properties': ['id1', 'id2', 'id3']}}])
+        state = {
+            'bookmarks':
+                 {
+                     'foo': {
+                         'max_pk_values': {'id1': 10, 'id2': 8, 'id3': 3}
+                     }
+                 }
+        }
+
+        expected = ' WHERE `id1` <= 10 AND `id2` <= \'8\' AND `id3` <= 3 ORDER BY `id1`, `id2`, `id3` ASC'
+        actual = generate_pk_clause(catalog_entry, state)
+
+        self.assertEqual(expected, actual)
+
+
+# Cases:
+# max_pk_values is Falsy X
+# last_pk_fetched is truthy X
+#   - Key_properties have something in it (1X and 3 pksX)
+# last_pk_fetched is falsy X
+#   - key_properties can be empty X (covered by first case)
+#   - key_properties has some (1 and 3 pks)
+# Try to get coverage reading
+# Revert and ensure they still pass and have same coverage


### PR DESCRIPTION
Currently, the resumable full_table query is built with the `WHERE` clause of the format:

```
WHERE pk1 > bookmark1 AND pk2 > bookmark2 ...
```

In this situation, it doesn't actually replicate all records in the table when resuming, due to the usage of `AND`. The set is bounded from below by the latest value for all columns in the PK exclusively, rather than cascading through the PK fields like the behavior of `ORDER BY`. This PR will change the query building for resuming full_table extraction to be of the form:

```
WHERE pk1 > bookmark1 OR (pk1 = bookmark1 AND pk2 > bookmark2) ...
```

This will give the tap a true bookmark into the previous, interrupted sync.