### PR TITLE
Use flags to determine if the current log is complete

### DIFF
--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -369,7 +369,7 @@ def _run_binlog_sync(mysql_conn, reader, binlog_streams_map, state):
                                 binlog_event.table)
 
         # NB: Flag 0x1 indicates that the binlog has been closed successfully, so we can rely on this being a complete log.
-        if binlog_event.flags & EVENT_FLAG_STMT_END_F:
+        if hasattr(binlog_event, 'flags') and binlog_event.flags & EVENT_FLAG_STMT_END_F:
             state = update_bookmarks(state,
                                      binlog_streams_map,
                                      reader.log_file,

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -43,8 +43,9 @@ mysql_timestamp_types = {
 # Event Flags
 # NB: Event flags are an unsigned short that accounts for flags on the event itself
 # Flag docs: https://dev.mysql.com/doc/internals/en/binlog-event-flag.html
-# - Note: `mysqlbinlog` calls 0x1 STMT_END_F, which we are using to decide if we need to bookmark
-EVENT_FLAG_STMT_END_F = 1 # Corresponds to the end log of a statement, regardless of how mysql breaks up the events
+# - Note: `mysqlbinlog` calls 0x0001 STMT_END_F, which we are using to decide if we need to bookmark
+LOG_EVENT_BINLOG_IN_USE_F = 0x0001 # Corresponds to the end log of a statement, set if log closed
+                                   # successfully after writing
 
 def add_automatic_properties(catalog_entry, columns):
     catalog_entry.schema.properties[SDC_DELETED_AT] = Schema(
@@ -369,7 +370,7 @@ def _run_binlog_sync(mysql_conn, reader, binlog_streams_map, state):
                                 binlog_event.table)
 
         # NB: Flag 0x1 indicates that the binlog has been closed successfully, so we can rely on this being a complete log.
-        if hasattr(binlog_event, 'flags') and binlog_event.flags & EVENT_FLAG_STMT_END_F:
+        if hasattr(binlog_event, 'flags') and binlog_event.flags & LOG_EVENT_BINLOG_IN_USE_F:
             state = update_bookmarks(state,
                                      binlog_streams_map,
                                      reader.log_file,


### PR DESCRIPTION
# Description of change
In some situations, we've observed binary logs get split into multiple events when a delete events happens with a where clause (e.g., `DELETE FROM table WHERE datetime BETWEEN '...' AND '...'`) that deletes a large amount of rows (~4k or so triggers it).

It has been reproduced with much effort that when the tap requests data from the log in the middle of the server writing this event, it will only get a subset of the events, but bookmark at the total statement event.

For example:
1. Log position 123 points to a DELETE query that covers ~4k rows
2. This gets written with 10 entries in the binary log
3. While this log is being written, the tap requests at position 123
4. The tap gets 1 entry that's marked complete, bookmarks 123, and exits (end of log)
5. On the next run, it will look for events greater than 123, skipping the 9 sub-events that were still being written to disk on the last run.

This PR relies on the flag at `0x1` in the `binlog_event.flags` value (which is an unsigned short) to indicate that an event corresponds to the last log in a chunked statement.

# QA steps
 - [ ] automated tests passing
 - [X] manual qa steps passing (list below)
   - Manual runs to reproduce this state
   - Manual inspection of binary log files to confirm that the flag only appears at the end of a chunked log entry
   - Investigation of MySQL docs to confirm that the flags value will be available
        - The tap is designed to work with 5.6.2 and up (for row-based logging), and this is greater than the version required for V3 logs where flags were added [here](https://dev.mysql.com/doc/internals/en/binlog-version.html)
 
# Risks
Medium, this is a change that was made with a rather narrow view. We'll need confirmation the this flag will be set on all committed records, though we have seen that this is the case with row-based logging enabled for our tests.

Another risk is that query events will prevent the log from moving forward, if there isn't a committed modification event in the time span of the tap run. Query events do not have this flag.

# Rollback steps
 - revert this branch, bump version, and release
