### PR TITLE
bump version to 1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 1.17.0
+  * Bump PyMySQL dependency from 0.7.11 to 0.9.3 [#116](https://github.com/singer-io/tap-mysql/pull/116)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-mysql',
-      version='1.16.0',
+      version='1.17.0',
       description='Singer.io tap for extracting data from MySQL',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
bump version to 1.17.0

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
None

# Rollback steps
 - revert this branch
