### PR TITLE
Fix Zero'd datetime/date/timestamp monkey patching

### DIFF
--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -16,6 +16,9 @@ from singer import utils
 LOGGER = singer.get_logger()
 
 
+#--------------------------------------------------------------------------------------------
+# Danger! Ugly monkey patching code ahead!
+#--------------------------------------------------------------------------------------------
 # NB: Upgrading pymysql from 0.7.11 --> 0.9.3 had the undocumented change
 # to how `0000-00-00 00:00:00` date/time types are returned. In 0.7.11,
 # they are returned as NULL, and in 0.9.3, they are returned as the string
@@ -38,6 +41,11 @@ def monkey_patch_date(date_str):
 
 pymysql.converters.convert_datetime = monkey_patch_datetime
 pymysql.converters.convert_date = monkey_patch_date
+
+pymysql.converters.conversions[pymysql.constants.FIELD_TYPE.DATETIME] = monkey_patch_datetime
+pymysql.converters.conversions[pymysql.constants.FIELD_TYPE.DATE] = monkey_patch_date
+#--------------------------------------------------------------------------------------------
+#--------------------------------------------------------------------------------------------
 
 def escape(string):
     if '`' in string:

--- a/tests/test_date_types.py
+++ b/tests/test_date_types.py
@@ -44,9 +44,9 @@ class TestDateTypes(unittest.TestCase):
 
         with connect_with_backoff(self.conn) as open_conn:
             with open_conn.cursor() as cursor:
-                cursor.execute('CREATE TABLE datetime_types (id int, datetime_col datetime, timestamp_col timestamp, time_col time)')
-                cursor.execute('INSERT INTO datetime_types (id, datetime_col, timestamp_col, time_col) VALUES (1, \'0000-00-00\', \'0000-00-00 00:00:00\', \'00:00:00\' )')
-                cursor.execute('INSERT INTO datetime_types (id, datetime_col, timestamp_col, time_col) VALUES (2, NULL, NULL, NULL)')
+                cursor.execute('CREATE TABLE datetime_types (id int, datetime_col datetime, timestamp_col timestamp, time_col time, date_col date)')
+                cursor.execute('INSERT INTO datetime_types (id, datetime_col, timestamp_col, time_col, date_col) VALUES (1, \'0000-00-00\', \'0000-00-00 00:00:00\', \'00:00:00\', \'0000-00-00\' )')
+                cursor.execute('INSERT INTO datetime_types (id, datetime_col, timestamp_col, time_col, date_col) VALUES (2, NULL, NULL, NULL, NULL)')
             open_conn.commit()
 
         self.catalog = test_utils.discover_catalog(self.conn, {})
@@ -64,7 +64,8 @@ class TestDateTypes(unittest.TestCase):
                 {'breadcrumb': ('properties', 'id'), 'metadata': {'selected': True}},
                 {'breadcrumb': ('properties', 'datetime_col'), 'metadata': {'selected': True}},
                 {'breadcrumb': ('properties', 'timestamp_col'), 'metadata': {'selected': True}},
-                {'breadcrumb': ('properties', 'time_col'), 'metadata': {'selected': True}}
+                {'breadcrumb': ('properties', 'time_col'), 'metadata': {'selected': True}},
+                {'breadcrumb': ('properties', 'date_col'), 'metadata': {'selected': True}}
             ]
 
             test_utils.set_replication_method_and_key(stream, 'LOG_BASED', None)
@@ -112,11 +113,13 @@ class TestDateTypes(unittest.TestCase):
             {'datetime_col': None,
              'id': 1,
              'timestamp_col': None,
-             'time_col': '1970-01-01T00:00:00.000000Z'},
+             'time_col': '1970-01-01T00:00:00.000000Z',
+             'date_col': None},
             {'datetime_col': None,
              'id': 2,
              'timestamp_col': None,
-             'time_col': None}
+             'time_col': None,
+             'date_col': None}
         ]
 
         self.assertEqual(expected_records, [x.asdict()['record'] for x in record_messages])


### PR DESCRIPTION
# Description of change
Fixes bug in #116 that caused values of `0000-00-00` of sql datatype `date` to error out since they weren't correctly changed to None.

# QA steps
 - [x] automated tests passing
   - Added `date` as a test case
 - [ ] manual qa steps passing (list below)
 
# Risks
None

# Rollback steps
 - revert this branch
