### PR TITLE
convert bytes to string in json returned by binlog

### DIFF
--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -136,7 +136,7 @@ def row_to_singer_record(catalog_entry, version, db_column_map, row, time_extrac
             the_utc_date = common.to_utc_datetime_str(val)
             row_to_persist[column_name] = the_utc_date
 
-        elif db_column_type == FIELD_TYPE.JSON and isinstance(val, dict):
+        elif db_column_type == FIELD_TYPE.JSON:
             row_to_persist[column_name] = json.dumps(json_bytes_to_string(val))
 
         elif 'boolean' in property_type or property_type == 'boolean':

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -4,6 +4,7 @@
 import copy
 
 import datetime
+import json
 import pytz
 import tzlocal
 
@@ -117,6 +118,12 @@ def fetch_server_id(mysql_conn):
 
             return server_id
 
+def json_bytes_to_string(data):
+    if isinstance(data, bytes):  return data.decode()
+    if isinstance(data, dict):   return dict(map(json_bytes_to_string, data.items()))
+    if isinstance(data, tuple):  return tuple(map(json_bytes_to_string, data))
+    if isinstance(data, list):   return list(map(json_bytes_to_string, data))
+    return data
 
 def row_to_singer_record(catalog_entry, version, db_column_map, row, time_extracted):
     row_to_persist = {}
@@ -129,6 +136,8 @@ def row_to_singer_record(catalog_entry, version, db_column_map, row, time_extrac
             the_utc_date = common.to_utc_datetime_str(val)
             row_to_persist[column_name] = the_utc_date
 
+        elif db_column_type == FIELD_TYPE.JSON and isinstance(val, dict):
+            row_to_persist[column_name] = json.dumps(json_bytes_to_string(val))
 
         elif 'boolean' in property_type or property_type == 'boolean':
             if val is None:


### PR DESCRIPTION
# Description of change
We recently introduced support for JSON columns in #111, but only tested for full table/incremental syncs, which use the PyMySQL library.  Binlog replication uses the PyMySQLReplication library, and JSON columns are returned from the binlog as dictionaries where all strings are encoded as bytes.  

This PR handles this by decoding all the bytes back to strings, and then stringifying the whole JSON blob to send along in the record.

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
   - Ran on cloned connection and verified that this resolved the error

# Risks
None

# Rollback steps
 - revert this branch
