### PR TITLE
Revert "Export JSON as a string and add test (#111)"

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -102,9 +102,6 @@ def schema_for_column(c):
     elif data_type in FLOAT_TYPES:
         result.type = ['null', 'number']
 
-    elif data_type == 'json':
-        result.type = ['null', 'string']
-
     elif data_type == 'decimal':
         result.type = ['null', 'number']
         result.multipleOf = 10 ** (0 - c.numeric_scale)

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -876,37 +876,6 @@ class TestEscaping(unittest.TestCase):
         self.assertTrue(isinstance(record_message, singer.RecordMessage))
         self.assertEqual(record_message.record, {'b c': 1})
 
-class TestJsonTables(unittest.TestCase):
-
-    def setUp(self):
-        self.conn = test_utils.get_test_connection()
-
-        with connect_with_backoff(self.conn) as open_conn:
-            with open_conn.cursor() as cursor:
-                cursor.execute('CREATE TABLE json_table (val json)')
-                cursor.execute('INSERT INTO json_table (val) VALUES ( \'{"a": 10, "b": "c"}\')')
-
-        self.catalog = test_utils.discover_catalog(self.conn, {})
-        for stream in self.catalog.streams:
-            stream.key_properties = []
-
-            stream.metadata = [
-                {'breadcrumb': (), 'metadata': {'selected': True, 'database-name': 'tap_mysql_test'}},
-                {'breadcrumb': ('properties', 'val'), 'metadata': {'selected': True}}
-            ]
-
-            stream.stream = stream.table
-            test_utils.set_replication_method_and_key(stream, 'FULL_TABLE', None)
-
-    def runTest(self):
-        global SINGER_MESSAGES
-        SINGER_MESSAGES.clear()
-        tap_mysql.do_sync(self.conn, {}, self.catalog, {})
-
-        record_message = list(filter(lambda m: isinstance(m, singer.RecordMessage), SINGER_MESSAGES))[0]
-        self.assertTrue(isinstance(record_message, singer.RecordMessage))
-        self.assertEqual(record_message.record, {'val': '{"a": 10, "b": "c"}'})
-
 class TestUnsupportedPK(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
# Description of change
This reverts commit bb1262205a4f41f3be901839fa0cac97a206d38b.
Removes support of json columns.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
