### PR TITLE
Fix/binlog empty update

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -102,9 +102,6 @@ def schema_for_column(c):
     elif data_type in FLOAT_TYPES:
         result.type = ['null', 'number']
 
-    elif data_type == 'json':
-        result.type = ['null', 'string']
-
     elif data_type == 'decimal':
         result.type = ['null', 'number']
         result.multipleOf = 10 ** (0 - c.numeric_scale)

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -352,12 +352,15 @@ def _run_binlog_sync(mysql_conn, reader, binlog_streams_map, state):
                                                          time_extracted)
 
                 elif isinstance(binlog_event, UpdateRowsEvent):
-                    rows_saved = handle_update_rows_event(binlog_event,
-                                                          catalog_entry,
-                                                          state,
-                                                          desired_columns,
-                                                          rows_saved,
-                                                          time_extracted)
+                    try:
+                        rows_saved = handle_update_rows_event(binlog_event,
+                                                              catalog_entry,
+                                                              state,
+                                                              desired_columns,
+                                                              rows_saved,
+                                                              time_extracted)
+                    except IndexError as err:
+                        LOGGER.warn('An update event seems to have updated 0 rows, skipping the event')
 
                 elif isinstance(binlog_event, DeleteRowsEvent):
                     rows_saved = handle_delete_rows_event(binlog_event,

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -876,37 +876,6 @@ class TestEscaping(unittest.TestCase):
         self.assertTrue(isinstance(record_message, singer.RecordMessage))
         self.assertEqual(record_message.record, {'b c': 1})
 
-class TestJsonTables(unittest.TestCase):
-
-    def setUp(self):
-        self.conn = test_utils.get_test_connection()
-
-        with connect_with_backoff(self.conn) as open_conn:
-            with open_conn.cursor() as cursor:
-                cursor.execute('CREATE TABLE json_table (val json)')
-                cursor.execute('INSERT INTO json_table (val) VALUES ( \'{"a": 10, "b": "c"}\')')
-
-        self.catalog = test_utils.discover_catalog(self.conn, {})
-        for stream in self.catalog.streams:
-            stream.key_properties = []
-
-            stream.metadata = [
-                {'breadcrumb': (), 'metadata': {'selected': True, 'database-name': 'tap_mysql_test'}},
-                {'breadcrumb': ('properties', 'val'), 'metadata': {'selected': True}}
-            ]
-
-            stream.stream = stream.table
-            test_utils.set_replication_method_and_key(stream, 'FULL_TABLE', None)
-
-    def runTest(self):
-        global SINGER_MESSAGES
-        SINGER_MESSAGES.clear()
-        tap_mysql.do_sync(self.conn, {}, self.catalog, {})
-
-        record_message = list(filter(lambda m: isinstance(m, singer.RecordMessage), SINGER_MESSAGES))[0]
-        self.assertTrue(isinstance(record_message, singer.RecordMessage))
-        self.assertEqual(record_message.record, {'val': '{"a": 10, "b": "c"}'})
-
 class TestUnsupportedPK(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
# Description of change
The tap can error because `mysql-replication`- the library we use to handle binlog syncs- throws an `IndexError` while reading the columns. 

# QA steps
 - [ ] automated tests passing
 - [x] manual qa steps passing (list below)
    - Ran the tap without this code, watched it fail
    - Ran the tap with the code and complete a sync successfully

# Risks
- Low: The error seems to only occur with update events. And if it's true that the updates with 0 affected rows are causing the error, then it doesn't seem like we'll lose any data

# Rollback steps
 - revert this branch
