### PR TITLE
bump version to 1.17.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.17.4
+  * Fix bookmarking of binlog to avoid skipping deletes [#115](https://github.com/singer-io/tap-mysql/pull/115)
+
 ## 1.17.3
   * Fix for python-mysql-replication bug where large json values cause errors [#122](https://github.com/singer-io/tap-mysql/pull/122)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-mysql',
-      version='1.17.3',
+      version='1.17.4',
       description='Singer.io tap for extracting data from MySQL',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
bump version to 1.17.4

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
n/a

# Rollback steps
 - revert this branch
