### PR TITLE
Write state before binlog

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -702,6 +702,10 @@ def sync_non_binlog_streams(mysql_conn, non_binlog_catalog, config, state):
 
 def sync_binlog_streams(mysql_conn, binlog_catalog, config, state):
     if binlog_catalog.streams:
+        # NB: Ensure state is up to date for consistency. State updates in
+        # Singer must be locked against concurrent updates, and writing
+        # state before binlog will make sure that this lock is claimed.
+        singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
         for stream in binlog_catalog.streams:
             write_schema_message(stream)
 


### PR DESCRIPTION
# Description of change
Binlog syncs have the possibility to have issues if updating state concurrently. This PR emits a State as a signpost to be used by a target and third party state management to ensure consistency of state writing.

# QA steps
 - [x] manual qa steps passing (list below)
   - Tested that target-stitch handles this message as expected
 
# Risks
Low, it's a single state emission addition for binlog only.

# Rollback steps
 - revert this branch, bump patch version
