### PR TITLE
Upgrade mysql replication 0.22

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='tap-mysql',
           'singer-python==5.9.0',
           'PyMySQL==0.9.3',
           'backoff==1.8.0',
-          'mysql-replication==0.18',
+          'mysql-replication==0.22',
       ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SRCE-3412 
Upgraded mysql replication to 0.22.

We went through and confirmed that the monkey patch in [6a55a13b](https://github.com/singer-io/tap-mysql/commit/6a55a13bec726da50d0ea3318dc965f570861e56) fixed the issue with our JSON test. Since 0.22 is released now, we're removing the monkeypatch and bumping the version. 


# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
    - Confirmed that the reverted commit is included in 0.22, confirmed it fixed the test
 
# Risks
Medium

# Rollback steps
 - revert this branch
 - bump version