### PR TITLE
bump to 1.17.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.17.5
+  * Revert #122, bump pymysql-replication to 0.22  [#133](https://github.com/singer-io/tap-mysql/pull/133)
+
 ## 1.17.4
   * Fix bookmarking of binlog to avoid skipping deletes [#115](https://github.com/singer-io/tap-mysql/pull/115)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-mysql',
-      version='1.17.4',
+      version='1.17.5',
       description='Singer.io tap for extracting data from MySQL',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
Revert #122, bump pymysql-replication to 0.22

# QA steps
none, version bump
 
# Risks
low

# Rollback steps
 - revert #133 and bump version
