### PR TITLE
move build time, use tap_tester_sandbox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run:
           name: 'Get environment variables'
           command: |
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
       - run:
           name: 'Setup virtual env'
           command: |
@@ -57,7 +57,7 @@ workflows:
   build_daily:
     triggers:
       - schedule:
-          cron: "0 12 * * *"
+          cron: "0 6 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
# Description of change
Move build time to early morning to avoid collisions, use the tap_tester_sandbox env.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
