### PR TITLE
Added makefile commands for developers to setup venv & run nose-tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+export TAP_MYSQL_PORT=3306
+export TAP_MYSQL_USER=root
+export TAP_MYSQL_PASSWORD=password
+export TAP_MYSQL_HOST=localhost

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,17 @@
 test:
 	SINGER_TAP_MYSQL_TEST_DB_HOST=localhost SINGER_TAP_MYSQL_TEST_DB_PORT=3306 SINGER_TAP_MYSQL_TEST_DB_USER=root SINGER_TAP_MYSQL_TEST_DB_PASSWORD=password nosetests
+
+start-dev-db:
+	TAP_MYSQL_PASSWORD=password	TAP_MYSQL_DBNAME=tap_mysql_test
+	python ./bin/test-db start 
+
+venv-test:
+	SINGER_TAP_MYSQL_TEST_DB_HOST=localhost SINGER_TAP_MYSQL_TEST_DB_PORT=3306 SINGER_TAP_MYSQL_TEST_DB_USER=root SINGER_TAP_MYSQL_TEST_DB_PASSWORD=password ;\
+	. ./venv/bin/activate ;\
+	nosetests tests/nosetests
+
+venv:
+	python3 -m venv venv ;\
+	. ./venv/bin/activate ;\
+	pip install --upgrade pip setuptools wheel ;\
+	pip install -e .[dev]


### PR DESCRIPTION
# Description of change
Adds 
- `make venv` to automatically build the developer environment
- `make venv-test` to run nose-tests inside the venv-environment locally
- `make start-dev-db` to interface the `test-db` script provided

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
None

# Rollback steps
 - revert this branch
