### PR TITLE
Backported explicit session-SQL support from pipelinewise-tap-mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ mysql> select * from example_db.animals;
 
 ### Create the configuration file
 
-Create a config file containing the database connection credentials, e.g.:
+Create a config file containing the database connection credentials. The required parameters are the same basic configuration properties used by the MySQL command-line client (`mysql`):
 
 ```json
 {
@@ -81,8 +81,17 @@ Create a config file containing the database connection credentials, e.g.:
 }
 ```
 
-These are the same basic configuration properties used by the MySQL command-line
-client (`mysql`).
+
+
+List of config parameters:
+
+| Parameter    | type                          | required | default                                                                                                                                                           | description                                                                                                               |
+|--------------|-------------------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| host         | string                        | Yes      | -                                                                                                                                                                 | mysql/mariadb host                                                                                                        |
+| port         | int                           | Yes      | -                                                                                                                                                                 | mysql/mariadb port                                                                                                        |
+| user         | string                        | Yes      | -                                                                                                                                                                 | db username                                                                                                               |
+| password     | string                        | Yes      | -                                                                                                                                                                 | db password                                                                                                               |
+| session_sqls | List of strings               | No       | ```['SET @@session.time_zone="+0:00"', 'SET @@session.wait_timeout=28800', 'SET @@session.net_read_timeout=3600', 'SET @@session.innodb_lock_wait_timeout=3600']``` | Set session variables dynamically.                                                                                        |
 
 ### Discovery mode
 

--- a/tests/nosetests/utils.py
+++ b/tests/nosetests/utils.py
@@ -20,7 +20,7 @@ def get_db_config():
     return config
 
 
-def get_test_connection():
+def get_test_connection(extra_config=None):
     db_config = get_db_config()
 
     con = pymysql.connect(**db_config)
@@ -38,7 +38,9 @@ def get_test_connection():
     db_config['database'] = DB_NAME
     db_config['autocommit'] = True
 
-    mysql_conn = MySQLConnection(db_config)
+    if not extra_config:
+        extra_config = {}
+    mysql_conn = MySQLConnection({**db_config, **extra_config})
     mysql_conn.autocommit_mode = True
 
     return mysql_conn


### PR DESCRIPTION
# Description of change
Introduces the ability to configure your own set of session SQL statements executed at connect-time. Changes backported from the upstream fork [pipelinewise-tap-mysql](https://github.com/transferwise/pipelinewise-tap-mysql) (specifically https://github.com/transferwise/pipelinewise-tap-mysql/pull/19), under the same original license used in this project (GNU Affero General Public License v3.0)

Resolves https://github.com/singer-io/tap-mysql/issues/126

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
New feature, so should be reviewed properly. Does not break any existing functionality.

# Rollback steps
 - revert this branch
